### PR TITLE
Add script to run CI on changed RBI files only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,25 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  GIT_DEFAULT_BRANCH: ${{github.event.repository.default_branch}}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    name: CI
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
           bundler-cache: true
       - name: Lint RBI files
-        run: bundle exec rubocop
+        run: scripts/run_on_changed_rbis "bundle exec rubocop"
       - name: Typecheck RBI files
-        run: scripts/check_types
+        run: scripts/run_on_changed_rbis scripts/check_types

--- a/scripts/check_types
+++ b/scripts/check_types
@@ -6,7 +6,8 @@ require "open3"
 success = true
 files_with_errors = []
 
-files = Dir.glob("./rbi/**/*").sort if ARGV.empty?
+files = ARGV.empty? ? Dir.glob("./rbi/**/*") : ARGV
+
 files.each do |file|
   next unless File.file?(file)
 

--- a/scripts/run_on_changed_rbis
+++ b/scripts/run_on_changed_rbis
@@ -1,0 +1,30 @@
+#! /usr/bin/env ruby
+
+unless ARGV.size == 1
+  $stderr.puts("usage: #{$0} <command_to_run>")
+  exit(1)
+end
+
+command = ARGV.first
+
+default_branch = ENV["GIT_DEFAULT_BRANCH"]
+current_branch = ENV["GITHUB_REF"].slice("refs/heads/")
+
+if current_branch == default_branch
+  $stderr.puts(command)
+  res = system(command)
+  exit(res)
+end
+
+lines = `git fetch origin #{default_branch} && git diff --name-only origin/#{default_branch} | grep "\.rbi$"`.lines
+files = lines.map(&:strip).select { |file| File.file?(file) }
+
+if lines.empty?
+  $stderr.puts("Nothing to check")
+  exit(0)
+end
+
+shell = "#{command} #{files.join(" ")}"
+$stderr.puts(shell)
+res = system(shell)
+exit(res)


### PR DESCRIPTION
Added a script that populates the next command with modified/new RBIs so that the CI would only run on those modified/new RBIs.
Examples:
- #13 Adds a new RBI successfully, only linting & typechecking the new file
- #14 Fails typechecking on a modified RBI, only linting & typechecking the modified file