### PR TITLE
CI Runs on Changed RBIs only (Success)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,25 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  GIT_DEFAULT_BRANCH: ${{github.event.repository.default_branch}}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    name: CI
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
           bundler-cache: true
       - name: Lint RBI files
-        run: bundle exec rubocop
+        run: scripts/run_on_changed_rbis "bundle exec rubocop"
       - name: Typecheck RBI files
-        run: scripts/check_types
+        run: scripts/run_on_changed_rbis scripts/check_types

--- a/rbi/annotations/grape.rbi
+++ b/rbi/annotations/grape.rbi
@@ -1,0 +1,3 @@
+# typed: strict
+
+class Grape::API < Grape::API::Instance; end

--- a/scripts/check_types
+++ b/scripts/check_types
@@ -6,6 +6,7 @@ require "open3"
 success = true
 files_with_errors = []
 
+*files = ARGV
 files = Dir.glob("./rbi/**/*").sort if ARGV.empty?
 files.each do |file|
   next unless File.file?(file)

--- a/scripts/run_on_changed_rbis
+++ b/scripts/run_on_changed_rbis
@@ -1,0 +1,30 @@
+#! /usr/bin/env ruby
+
+unless ARGV.size == 1
+  $stderr.puts("usage: #{$0} <command_to_run>")
+  exit(1)
+end
+
+command = ARGV.first
+
+default_branch = ENV["GIT_DEFAULT_BRANCH"]
+current_branch = ENV["GITHUB_REF"].slice("refs/heads/")
+
+if current_branch == default_branch
+  $stderr.puts(command)
+  res = system(command)
+  exit(res)
+end
+
+lines = `git fetch origin #{default_branch} && git diff --name-only origin/#{default_branch} | grep "\.rbi$"`.lines
+files = lines.map(&:strip).select { |file| File.file?(file) }
+
+if lines.empty?
+  $stderr.puts("Nothing to check")
+  exit(0)
+end
+
+shell = "#{command} #{files.join(" ")}"
+$stderr.puts(shell)
+res = system(shell)
+exit(res)


### PR DESCRIPTION
This is an example of a successful CI check. If you go to the checks and examine the linting and typechecking, you'll see the tests only ran on `grape.rbi` which is the new RBI file.