### PR TITLE
CI Runs on Changed RBIs (Failure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,25 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  GIT_DEFAULT_BRANCH: ${{github.event.repository.default_branch}}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    name: CI
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
           bundler-cache: true
       - name: Lint RBI files
-        run: bundle exec rubocop
+        run: scripts/run_on_changed_rbis "bundle exec rubocop"
       - name: Typecheck RBI files
-        run: scripts/check_types
+        run: scripts/run_on_changed_rbis scripts/check_types

--- a/rbi/annotations/elasticsearch-dsl.rbi
+++ b/rbi/annotations/elasticsearch-dsl.rbi
@@ -1,8 +1,8 @@
 # typed: true
 
 module Elasticsearch::DSL::Search
-  sig { params(args: T.untyped, block: T.proc.bind(Elasticsearch::DSL::Search::Search).void).void }
-  def self.search(*args, &block); end
+  sig { params(block: T.proc.bind(Elasticsearch::DSL::Search::Search).void).void }
+  def self.search(&block); end
 end
 
 class Elasticsearch::DSL::Search::Search
@@ -44,7 +44,7 @@ class Elasticsearch::DSL::Search::Filters::Bool
 end
 
 class Elasticsearch::DSL::Search::Filter
-  sig { params(value: T.nilable(T.any(String, Symbol)), block: T.proc.bind(Elasticsearch::DSL::Search::Queries::QueryString).void).void }
+  sig { params(value: T.nilable(T.any(String, Symbol)), block: T.proc.bind(Elasticsearch::DSL::Search::Queries::QueryString).void) }
   def query_string(value = nil, &block); end
 
   sig { params(value: T.any(String, Symbol), block: T.nilable(T.proc.bind(Elasticsearch::DSL::Search::Queries::Prefix).void)).void }

--- a/scripts/check_types
+++ b/scripts/check_types
@@ -6,6 +6,7 @@ require "open3"
 success = true
 files_with_errors = []
 
+*files = ARGV
 files = Dir.glob("./rbi/**/*").sort if ARGV.empty?
 files.each do |file|
   next unless File.file?(file)

--- a/scripts/run_on_changed_rbis
+++ b/scripts/run_on_changed_rbis
@@ -1,0 +1,30 @@
+#! /usr/bin/env ruby
+
+unless ARGV.size == 1
+  $stderr.puts("usage: #{$0} <command_to_run>")
+  exit(1)
+end
+
+command = ARGV.first
+
+default_branch = ENV["GIT_DEFAULT_BRANCH"]
+current_branch = ENV["GITHUB_REF"].slice("refs/heads/")
+
+if current_branch == default_branch
+  $stderr.puts(command)
+  res = system(command)
+  exit(res)
+end
+
+lines = `git fetch origin #{default_branch} && git diff --name-only origin/#{default_branch} | grep "\.rbi$"`.lines
+files = lines.map(&:strip).select { |file| File.file?(file) }
+
+if lines.empty?
+  $stderr.puts("Nothing to check")
+  exit(0)
+end
+
+shell = "#{command} #{files.join(" ")}"
+$stderr.puts(shell)
+res = system(shell)
+exit(res)


### PR DESCRIPTION
This is an example of a failed CI check. If you go to the checks and examine the linting and typechecking, you'll see the tests only ran on the modified file (`elasticsearch.dsl.rbi`) and found a typechecking error.