### PR TITLE
Failure to lint index.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,5 @@ jobs:
         run: scripts/run_on_changed_rbis "bundle exec rubocop"
       - name: Typecheck RBI files
         run: scripts/run_on_changed_rbis scripts/check_types
+      - name: Lint index.json
+        run: scripts/lint_index_json

--- a/index.json
+++ b/index.json
@@ -1,4 +1,6 @@
 {
-  "activesupport": {},
-  "elasticsearch-dsl": {}
+  "activesupport": {
+  },
+  "elasticsearch-dsl": {
+  }
 }

--- a/index.json
+++ b/index.json
@@ -1,6 +1,4 @@
 {
-  "activesupport": {
-  },
-  "elasticsearch-dsl": {
-  }
+  "activesupport": {},
+  "elasticsearch-dsl": {}
 }

--- a/scripts/lint_index_json
+++ b/scripts/lint_index_json
@@ -1,0 +1,35 @@
+#! /usr/bin/env ruby
+
+require "pathname"
+require "open3"
+require "json"
+require "fileutils"
+
+index_path = "./index.json"
+index_json = File.read(index_path)
+
+begin
+  index = JSON.parse(index_json)
+rescue => e
+  error = e.message.sub(/^[0-9]+: /, "")
+  $stderr.puts("Invalid JSON for index: #{error}")
+  exit(1)
+end
+
+sorted = Hash[index.sort]
+expected_json = JSON.pretty_generate(sorted) << "\n"
+expected_path = "index.expected.json"
+File.write(expected_path, expected_json)
+
+out, status = Open3.capture2e("diff -u #{index_path} #{expected_path}")
+if status.success?
+  $stderr.puts("No errors, good job!")
+  FileUtils.rm(expected_path)
+  exit(0)
+end
+
+$stderr.puts("Formatting errors found in index.json:")
+$stderr.puts("\n#{out}\n")
+
+FileUtils.rm(expected_path)
+exit(1)


### PR DESCRIPTION
In this example, the `index.json` fails to lint. The error message in the CI appears:
```
Formatting errors found in index.json:

--- ./index.json	2022-05-26 1[7](https://github.com/Shopify/rbi-central/runs/6613592627?check_suite_focus=true#step:6:8):1[8](https://github.com/Shopify/rbi-central/runs/6613592627?check_suite_focus=true#step:6:9):5[9](https://github.com/Shopify/rbi-central/runs/6613592627?check_suite_focus=true#step:6:10).024820369 +0000
+++ index.expected.json	2022-05-26 17:19:03.829119135 +0000
@@ -1,4 +1,6 @@
 {
-  "activesupport": {},
-  "elasticsearch-dsl": {}
+  "activesupport": {
+  },
+  "elasticsearch-dsl": {
+  }
 }
```