### PR TITLE
Example: `index.json` missing `grape.rbi`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,5 @@ jobs:
         run: scripts/run_on_changed_rbis scripts/check_types
       - name: Lint index.json
         run: scripts/lint_index_json
+      - name: Check index.json entries match rbi/annotations/*.rbi files
+        run: scripts/match_index_entries_with_rbis

--- a/rbi/annotations/grape.rbi
+++ b/rbi/annotations/grape.rbi
@@ -1,0 +1,3 @@
+# typed: strict
+
+class Grape::API < Grape::API::Instance; end

--- a/scripts/match_index_entries_with_rbis
+++ b/scripts/match_index_entries_with_rbis
@@ -1,0 +1,36 @@
+#! /usr/bin/env ruby
+
+require "fileutils"
+require "json"
+require "pathname"
+
+$stderr.puts("Checking index validity...\n\n")
+
+index = JSON.parse(File.read("./index.json"))
+
+rbis_path = "rbi/annotations"
+rbis = Dir.glob("#{rbis_path}/*.rbi").sort
+success = true
+
+index.each do |gem_name, _|
+  file = "#{rbis_path}/#{gem_name}.rbi"
+  rbis.delete(file)
+
+  unless File.file?(file)
+    $stderr.puts("Missing RBI file matching index entry `#{gem_name}` (`#{file}` was expected but not found)")
+    success = false
+    next
+  end
+end
+
+unless rbis.empty?
+  rbis.each do |path|
+    next unless File.file?(path)
+    $stderr.puts("Missing index entry matching RBI file `#{path}`")
+    success = false
+  end
+end
+
+$stderr.puts("No errors, good job!") if success
+
+exit(success)


### PR DESCRIPTION
In this example, the `index.json` is missing `grape` so the CI fails. The error message in the CI appears:
```
Checking index validity...

Missing index entry matching RBI file `rbi/annotations/grape.rbi`
Error: Process completed with exit code 1.
```