### PR TITLE
Example: `index.json` contains an rbi that doesn't appear in `rbi/annotations`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,5 @@ jobs:
         run: scripts/run_on_changed_rbis scripts/check_types
       - name: Lint index.json
         run: scripts/lint_index_json
+      - name: Check index.json entries match rbi/annotations/*.rbi files
+        run: scripts/match_index_entries_with_rbis

--- a/index.json
+++ b/index.json
@@ -2,5 +2,7 @@
   "activesupport": {
   },
   "elasticsearch-dsl": {
+  },
+  "grape": {
   }
 }

--- a/scripts/match_index_entries_with_rbis
+++ b/scripts/match_index_entries_with_rbis
@@ -1,0 +1,36 @@
+#! /usr/bin/env ruby
+
+require "fileutils"
+require "json"
+require "pathname"
+
+$stderr.puts("Checking index validity...\n\n")
+
+index = JSON.parse(File.read("./index.json"))
+
+rbis_path = "rbi/annotations"
+rbis = Dir.glob("#{rbis_path}/*.rbi").sort
+success = true
+
+index.each do |gem_name, _|
+  file = "#{rbis_path}/#{gem_name}.rbi"
+  rbis.delete(file)
+
+  unless File.file?(file)
+    $stderr.puts("Missing RBI file matching index entry `#{gem_name}` (`#{file}` was expected but not found)")
+    success = false
+    next
+  end
+end
+
+unless rbis.empty?
+  rbis.each do |path|
+    next unless File.file?(path)
+    $stderr.puts("Missing index entry matching RBI file `#{path}`")
+    success = false
+  end
+end
+
+$stderr.puts("No errors, good job!") if success
+
+exit(success)


### PR DESCRIPTION
In this example, the `index.json` contains an rbi (`grape`) that doesn't appear in `rbi/annotations`. The error message in the CI appears: