### PR TITLE
Add annotations for `ActiveSupport::TestCase`

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -1,5 +1,13 @@
 # typed: strict
 
+class ActiveSupport::TestCase
+  sig { params(args: T.untyped, block: T.proc.bind(T.attached_class).void).void }
+  def self.setup(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.proc.bind(T.attached_class).void).void }
+  def self.teardown(*args, &block); end
+end
+
 class String
   sig { returns(T::Boolean) }
   def blank?; end


### PR DESCRIPTION
As defined here: https://api.rubyonrails.org/v7.0/classes/ActiveSupport/Testing/SetupAndTeardown/ClassMethods.html#method-i-teardown

Note that we do not define the signatures on `ActiveSupport::Testing::SetupAndTeardown::ClassMethods` itself as it would prohibit us to use `T.attached_class` in the proc bind. Instead we define the signatures on `ActiveSupport::TestCase` which extends the module and is generally the class being used.

[[sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20ActiveSupport%3A%3ATestCase%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20params%28args%3A%20T.untyped%2C%20block%3A%20T.proc.bind%28T.attached_class%29.void%29.void%20%7D%0A%20%20def%20self.setup%28*args%2C%20%26block%29%3B%20end%0A%0A%20%20sig%20%7B%20params%28args%3A%20T.untyped%2C%20block%3A%20T.proc.bind%28T.attached_class%29.void%29.void%20%7D%0A%20%20def%20self.teardown%28*args%2C%20%26block%29%3B%20end%0Aend%0A%0Aclass%20MyTest%20%3C%20ActiveSupport%3A%3ATestCase%0A%20%20setup%20do%0A%20%20%20%20some_method_used_in_tests%0A%20%20end%0A%0A%20%20teardown%20do%0A%20%20%20%20some_method_used_in_tests%0A%20%20end%0A%0A%20%20private%0A%0A%20%20def%20some_method_used_in_tests%3B%20end%0Aend%0A)]