### PR TITLE
Add annotation for `ActiveRecord::TestCase.test`

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -6,6 +6,9 @@ class ActiveSupport::TestCase
 
   sig { params(args: T.untyped, block: T.proc.bind(T.attached_class).void).void }
   def self.teardown(*args, &block); end
+
+  sig { params(name: String, block: T.proc.bind(T.attached_class).void).void }
+  def self.test(name, &block); end
 end
 
 class String


### PR DESCRIPTION
Follow-up on #31.

As described [here](https://api.rubyonrails.org/v7.0/classes/ActiveSupport/Testing/Declarative.html#method-i-test), the method takes the name as a `String` and binds the block to the attached class.

Like in #31 we define the signature on the `TestCase` class so we can bind the proc to `T.attached_class`.