### PR TITLE
Ensure new gems added are public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: scripts/run_on_changed_rbis "bundle exec rubocop"
       - name: Typecheck RBI files
         run: scripts/run_on_changed_rbis scripts/check_types
+      - name: Check new RBI files belong to public gems
+        run: scripts/run_on_changed_rbis scripts/check_gems_are_public
       - name: Lint index.json
         run: scripts/lint_index_json
       - name: Check index.json entries match rbi/annotations/*.rbi files

--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ $ bin/tapioca annotations
 
 The CI for this repository is written using GitHub Actions. Here is a list of currently available CI checks:
 
-| CLI Command                                         | Description                                                    |
-| --------------------------------------------------- | -------------------------------------------------------------- |
-| `scripts/run_on_changed_rbis "bundle exec rubocop"` | Lint RBI files                                                 |
-| `scripts/run_on_changed_rbis scripts/check_types`   | Typecheck RBI files                                            |
-| `scripts/lint_index_json`                           | Lint `index.json`                                              |
-| `scripts/match_index_entries_with_rbis`             | Check `index.json` entries match `rbi/annotations/*.rbi` files |
-| `bundle exec rubocop`                               | Ensure all RBI files in the repo use the sigil `strict`        |
+| CLI Command                                                 | Description                                                    |
+| ----------------------------------------------------------- | -------------------------------------------------------------- |
+| `scripts/run_on_changed_rbis "bundle exec rubocop"`         | Lint RBI files                                                 |
+| `scripts/run_on_changed_rbis scripts/check_types`           | Typecheck RBI files                                            |
+| `scripts/run_on_changed_rbis scripts/check_gems_are_public` | Check new RBI files belong to public gems                      |
+| `scripts/lint_index_json`                                   | Lint `index.json`                                              |
+| `scripts/match_index_entries_with_rbis`                     | Check `index.json` entries match `rbi/annotations/*.rbi` files |
+| `bundle exec rubocop`                                       | Ensure all RBI files in the repo use the sigil `strict`        |
 
 All scripts used in the CI checks are located in the `scripts` folder.
 

--- a/scripts/check_gems_are_public
+++ b/scripts/check_gems_are_public
@@ -1,0 +1,32 @@
+#! /usr/bin/env ruby
+
+require "net/http"
+require "json"
+
+success = true
+
+files = ARGV.empty? ? Dir.glob("./rbi/**/*") : ARGV
+
+files.each do |file|
+  next unless File.file?(file)
+
+  gem = File.basename(file, File.extname(file))
+  $stderr.puts("Checking if gem `#{gem}` is public...")
+  uri = URI("https://rubygems.org/api/v1/versions/#{gem}/latest.json")
+  content = Net::HTTP.get(uri)
+  version = JSON.parse(content)["version"]
+
+  if version === "9001.0" || version === "unknown"
+    $stderr.puts("  Error: `#{gem}` doesn't seem to be a public")
+    $strerr.puts("  Make sure your gem is available at https://rubygems.org/gems/#{gem}")
+    success = false
+  end
+end
+
+$stderr.puts("\n")
+
+if success
+  $stderr.puts("All gems are public, good job!")
+end
+
+exit(success)


### PR DESCRIPTION
Added a script to ensure that the annotations being added are for public gems only.
Examples: 
- #34 (Success example)
- #35 (Failure example)