### PR TITLE
Add a pre-push git hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,47 @@
+#! /usr/bin/env ruby
+
+$stderr.puts("Running pre-push validation...")
+
+lines = `git fetch origin main 2> /dev/null && git diff --name-only origin/main | grep -E "\.rbi$|index.json"`.lines
+files = lines.map(&:strip).select { |file| File.file?(file) }
+rbis = files.select { |file| File.extname(file) === ".rbi"}
+
+if lines.empty?
+  $stderr.puts("Nothing to check")
+  $stderr.puts("\n")
+  exit(0)
+end
+
+success = true
+
+unless rbis.empty?
+  $stderr.puts("Linting RBI files...")
+  unless system("bundle exec rubocop #{rbis.join(" ")}")
+    success = false
+  end
+  $stderr.puts("Type checking RBI files...")
+  unless system("scripts/check_types #{rbis.join(" ")}")
+    success = false
+  end
+  $stderr.puts("Checking that new RBI files belong to public gems...")
+  unless system("scripts/check_gems_are_public #{rbis.join(" ")}")
+    success = false
+  end
+end
+
+$stderr.puts("Linting index.json...")
+unless system("scripts/lint_index_json")
+  success = false
+end
+$stderr.puts("Checking that index.json entries match rbi/annotations/*.rbi files...")
+unless system("scripts/match_index_entries_with_rbis")
+  success = false
+end
+
+unless success
+  $stderr.puts("Cancelling the push as the code fails at least one check (see above)")
+  exit(1)
+end
+
+$stderr.puts("\n")
+exit(0)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ The CI for this repository is written using GitHub Actions. Here is a list of cu
 
 All scripts used in the CI checks are located in the `scripts` folder.
 
+To avoid pushing a PR with errors, configure the `pre-push` git hook by running:
+
+```shell
+$ git config core.hooksPath .githooks
+```
+
+This git hook will run most of the CI checks and block the push if you don't pass all the tests.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Shopify/rbi-central.

--- a/scripts/check_gems_are_public
+++ b/scripts/check_gems_are_public
@@ -18,7 +18,7 @@ files.each do |file|
 
   if version === "9001.0" || version === "unknown"
     $stderr.puts("  Error: `#{gem}` doesn't seem to be a public")
-    $strerr.puts("  Make sure your gem is available at https://rubygems.org/gems/#{gem}")
+    $stderr.puts("  Make sure your gem is available at https://rubygems.org/gems/#{gem}")
     success = false
   end
 end


### PR DESCRIPTION
Added a `pre-push` git hook with the main intention of preventing people from pushing annotations for private gems. Included the other CI tests as well for fun.

Usually hooks go in `.git/hooks` but `.git` is not tracked so I looked into solutions for how to share git hooks and found that by placing the git hooks in an arbitrary folder (I named this one `.githooks`) it could be tracked and included with the repository and then anyone using the repository could run `git config core.hooksPath .githooks` to configure it.

Making a branch with an example of a failure would be difficult since the `pre-push` git hook prevents me from pushing it but you can use any of the failure examples from the past to test with and they will still all fail, just this time before you even push:
- #3 
- #4 
- #19 
- #20 
- #35 