### PR TITLE
Add a Sorbet config so we can use the VSCode plugin

### DIFF
--- a/scripts/check_types
+++ b/scripts/check_types
@@ -15,8 +15,7 @@ files.each do |file|
   $stderr.puts("Typechecking `#{file}`...")
 
   out, status = Open3.capture2e(
-    "bundle exec srb tc #{file} --no-error-count " \
-      "--suppress-error-code=5002,5020,5035,5067"
+    "bundle exec srb tc #{file} --no-config --no-error-count --suppress-error-code=5002,5020,5035,5067"
   )
   $stderr.puts("\n#{out}\n") unless out.empty?
   unless status.success?

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,0 +1,2 @@
+rbi/
+--suppress-error-code=5002,5020,5035,5067


### PR DESCRIPTION
Supressing error codes [5002](https://sorbet.org/docs/error-reference#5002), [5020](https://sorbet.org/docs/error-reference#5020), [5035](https://sorbet.org/docs/error-reference#5035) and [5067](https://sorbet.org/docs/error-reference#5067) as they do not make sense for partial definitions.