### PR TITLE
Do not run rubocop twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,3 @@ jobs:
         run: scripts/lint_index_json
       - name: Check index.json entries match rbi/annotations/*.rbi files
         run: scripts/match_index_entries_with_rbis
-      - name: Ensure all RBI files in the repo use the sigil "strict"
-        run: bundle exec rubocop


### PR DESCRIPTION
We don't need to run rubocop specifically for sigils since it's already covered by `Lint RBI files`.

Example: https://github.com/Shopify/rbi-central/compare/at-remove-extra-rubocop-example.