### PR TITLE
Remove wrong RBI for grape

### DIFF
--- a/index.json
+++ b/index.json
@@ -11,8 +11,6 @@
   },
   "faraday": {
   },
-  "grape": {
-  },
   "mocha": {
   },
   "rails": {

--- a/rbi/annotations/grape.rbi
+++ b/rbi/annotations/grape.rbi
@@ -1,3 +1,0 @@
-# typed: strict
-
-class Grape::API < Grape::API::Instance; end


### PR DESCRIPTION
This was a wrong way to represent the `inherited` hook [on `Grape::API`](https://github.com/ruby-grape/grape/blob/master/lib/grape/api.rb#L33-L40).

The correct way would be to create a DSL generator for it.