### PR TITLE
Use bundler/setup on check_index

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,7 +30,7 @@ unless rbis.empty?
 end
 
 $stderr.puts("Checking index.json...")
-unless system("bundle exec scripts/check_index")
+unless system("scripts/check_index")
   success = false
 end
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           ruby-version: '2.7'
           bundler-cache: true
       - name: Check index.json
-        run: bundle exec scripts/check_index
+        run: scripts/check_index
       - name: Lint RBI files
         run: scripts/run_on_changed_rbis "bundle exec rubocop"
       - name: Typecheck RBI files

--- a/scripts/check_index
+++ b/scripts/check_index
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 
+require "bundler/setup"
 require "json-schema"
 require "open3"
 


### PR DESCRIPTION
As pointed by @rafaelfranca in https://github.com/Shopify/rbi-central/pull/54#discussion_r909016536, we do not need to pass `bundle exec` everywhere.