### PR TITLE
Add `check_all` script

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 
-$stderr.puts("Running pre-push validation...")
+$stderr.puts("Running pre-push validation...\n\n")
 
 lines = `git fetch origin main 2> /dev/null && git diff --name-only origin/main | grep -E "\.rbi$|index.json"`.lines
 files = lines.map(&:strip).select { |file| File.file?(file) }
@@ -12,35 +12,8 @@ if lines.empty?
   exit(0)
 end
 
-success = true
-
-unless rbis.empty?
-  $stderr.puts("Linting RBI files...")
-  unless system("bundle exec rubocop #{rbis.join(" ")}")
-    success = false
-  end
-  $stderr.puts("Checking that new RBI files belong to public gems...")
-  unless system("scripts/check_gems_are_public #{rbis.join(" ")}")
-    success = false
-  end
-  $stderr.puts("Checking RBI files against runtime execution...")
-  unless system("scripts/check_runtime #{rbis.join(" ")}")
-    success = false
-  end
-
-  $stderr.puts("Checking RBI files against Tapioca and Sorbet...")
-  unless system("scripts/check_static #{rbis.join(" ")}")
-    success = false
-  end
-end
-
-$stderr.puts("Checking index.json...")
-unless system("scripts/check_index")
-  success = false
-end
-
-unless success
-  $stderr.puts("Cancelling the push as the code fails at least one check (see above)")
+unless system("scripts/check_all #{rbis.join(" ")}")
+  $stderr.puts("\nSome checks have failed, cancelling the push (see above)")
   exit(1)
 end
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,5 @@ jobs:
         with:
           ruby-version: '2.7'
           bundler-cache: true
-      - name: Check index.json
-        run: scripts/check_index
-      - name: Lint RBI files
-        run: scripts/run_on_changed_rbis "bundle exec rubocop"
-      - name: Check new RBI files belong to public gems
-        run: scripts/run_on_changed_rbis scripts/check_gems_are_public
-      - name: Check RBI definitions against runtime execution
-        run: scripts/run_on_changed_rbis "scripts/check_runtime"
-      - name: Check RBI definitions against Tapioca generated RBIs and Sorbet
-        run: scripts/run_on_changed_rbis "scripts/check_static"
+      - name: Check RBIs and index
+        run: scripts/run_on_changed_rbis "scripts/check_all"

--- a/scripts/check_all
+++ b/scripts/check_all
@@ -1,0 +1,27 @@
+#! /usr/bin/env ruby
+
+require "bundler/setup"
+
+require_relative "utils/rbi_validator"
+
+success = true
+
+$stderr.puts("### Checking index...\n\n")
+success &= system("scripts/check_index")
+
+files = rbi_files.join(" ")
+unless files.empty?
+  $stderr.puts("\n### Linting RBI files...\n\n")
+  success &= system("bundle exec rubocop #{files}")
+
+  $stderr.puts("\n### Checking that all RBI files belong to public gems...\n\n")
+  success &= system("scripts/check_gems_are_public #{files}")
+
+  $stderr.puts("\n### Checking RBI files against runtime execution...\n\n")
+  success &= system("scripts/check_runtime #{files}")
+
+  $stderr.puts("\n### Checking RBI files against Tapioca and Sorbet...\n\n")
+  success &= system("scripts/check_static #{files}")
+end
+
+exit(success)


### PR DESCRIPTION
A script to run all the tests at once.

Usage:

```
# Check all tests on all files
./scripts/check_all 

# Check all tests on specified files
./scripts/check_all rbi/annotations/a.rbi rbi/annotations/b.rbi
```

All tests will be executed regardless of previous failures. That means that you still have the result of `check_runtime` even if `check_index` failed for example.

Also updated the git hook and CI to use it.

Example of failure: https://github.com/Shopify/rbi-central/compare/at-check-all-example?expand=1