### PR TITLE
Bump rubocop to v0.6.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       parser (>= 3.1.1.0)
     rubocop-shopify (2.5.0)
       rubocop (~> 1.25)
-    rubocop-sorbet (0.6.8)
+    rubocop-sorbet (0.6.11)
       rubocop (>= 0.90.0)
     ruby-progressbar (1.11.0)
     sorbet (0.5.10001)


### PR DESCRIPTION
So constants are sorted first (see https://github.com/Shopify/rubocop-sorbet/pull/113)