### PR TITLE
Use ignore instead of a specific path

### DIFF
--- a/sorbet/config
+++ b/sorbet/config
@@ -1,2 +1,4 @@
-rbi/
+.
+--ignore=vendor/
+--ignore=scripts/
 --suppress-error-code=5002,5020,5035,5067


### PR DESCRIPTION
The previous config was somehow tricking Sorbet's LSP indexed thinking we had two dirs: `rbi/annotations` and `annotations` to check and was duplicating some errors.