### PR TITLE
Correct Lhm::Printer::Dot#notify arguments

### DIFF
--- a/rbi/annotations/lhm.rbi
+++ b/rbi/annotations/lhm.rbi
@@ -91,8 +91,8 @@ class Lhm::Printer::Dot < Lhm::Printer::Base
   sig { void }
   def end; end
 
-  sig { params(lowest: T.nilable(Numeric), highest: T.nilable(Numeric)).void }
-  def notify(lowest = nil, highest = nil); end
+  sig { params(_arg0: T.untyped).void }
+  def notify(*_arg0); end
 end
 
 class Lhm::Migrator


### PR DESCRIPTION
The [actual implementation](https://github.com/Shopify/lhm/blob/636fb465da29c5f4e6c5d55ba2393f46905018e5/lib/lhm/printer.rb#L54) uses just a `*` argument. The mismatch is causing conflicts with the RBI generated by Tapioca.