### PR TITLE
Add annotations for the `aws-sdk-acm` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/index.json
+++ b/index.json
@@ -30,6 +30,8 @@
       "active_support/test_case"
     ]
   },
+  "aws-sdk-acm": {
+  },
   "bencode": {
   },
   "colorize": {

--- a/rbi/annotations/aws-sdk-acm.rbi
+++ b/rbi/annotations/aws-sdk-acm.rbi
@@ -1,0 +1,40 @@
+# typed: strict
+
+class Aws::ACM::Client
+  sig { params(params: T.untyped, options: T.untyped).returns(Aws::ACM::Types::DescribeCertificateResponse) }
+  def describe_certificate(params = nil, options = nil); end
+end
+
+class Aws::ACM::Types::DescribeCertificateResponse
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { returns(Aws::ACM::Types::CertificateDetail) }
+  attr_accessor :certificate
+end
+
+class Aws::ACM::Types::CertificateDetail
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { returns(T.nilable(T::Array[Aws::ACM::Types::DomainValidation])) }
+  attr_accessor :domain_validation_options
+end
+
+class Aws::ACM::Types::DomainValidation
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { returns(Aws::ACM::Types::ResourceRecord) }
+  attr_accessor :resource_record
+end
+
+class Aws::ACM::Types::ResourceRecord
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { returns(String) }
+  attr_accessor :name
+
+  sig { returns(String) }
+  attr_accessor :type
+
+  sig { returns(String) }
+  attr_accessor :value
+end


### PR DESCRIPTION
This gem has a large number of types so this will most likely be incremental, but the types added here so far are
necessary for the project I'm currently working on.