### PR TITLE
Rails.env returns an EnvironmentInquirer

### DIFF
--- a/rbi/annotations/railties.rbi
+++ b/rbi/annotations/railties.rbi
@@ -11,7 +11,7 @@ module Rails
     sig { returns(ActiveSupport::Cache::Store) }
     def cache; end
 
-    sig { returns(ActiveSupport::StringInquirer) }
+    sig { returns(ActiveSupport::EnvironmentInquirer) }
     def env; end
 
     sig { returns(ActiveSupport::Logger) }


### PR DESCRIPTION
Otherwise `Rails.env.development?` fails to typecheck

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: railties
* Gem version: 6.0.5
* Gem source: https://github.com/rails/rails
* Gem API doc: N/A
* Tapioca version: 0.9.2
* Sorbet version: 0.5.10201