### PR TITLE
Add yard.rbi with root log method

### DIFF
--- a/rbi/annotations/yard.rbi
+++ b/rbi/annotations/yard.rbi
@@ -1,0 +1,4 @@
+# typed: strict
+
+sig { returns(YARD::Logger) }
+def log; end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: yard <!-- Add the name of the gem you have a problem with here -->
* Gem version: <!-- Add the version of the gem you have a problem with here (if applicable) -->
* Gem source: https://github.com/lsegal/yard <!-- Link relevant source code from the gem for the problem you have -->
* Gem API doc: https://rubydoc.info/gems/yard/0.9.28/toplevel#log-instance_method <!-- Link relevant API doc from the gem for the problem you have -->
* Tapioca version: 0.9.2 <!-- Add the version of Tapioca you use -->
* Sorbet version: 0.5.10285 <!-- Add the version of Sorbet you use -->

Adds the `log` method in an attempt to solve the problem posted [here](https://sorbet-ruby.slack.com/archives/C02VD06EQ3U/p1659826763215239) (and pasted below):

I'm attempting to migrate `yard-sorbet` to use `tapioca` for RBI generation. WIP PR: https://github.com/dduugg/yard-sorbet/pull/103
I'm following the migration guide: https://github.com/Shopify/tapioca/wiki/Migrating-to-Tapioca
However, typechecking is currently failing:
```
$ be srb tc                                                                                                                         [15:52:16]
lib/yard-sorbet/sig_to_yard.rb:60: Method log does not exist on T.class_of(YARDSorbet::SigToYARD) https://srb.help/7003
    60 |        log.info("Unsupported sig aref node #{node.source}")
                ^^^

lib/yard-sorbet/sig_to_yard.rb:126: Method log does not exist on T.class_of(YARDSorbet::SigToYARD) https://srb.help/7003
     126 |      log.warn("Unsupported sig #{node.type} node #{node.source}")
                ^^^
Errors: 2
FAIL
```
`log` is defined by `yard` here: https://github.com/lsegal/yard/blob/main/lib/yard/globals.rb#L20-L22
My understanding is that I should be able to resolve this by adding requiring `yard/globals` in `tapioca/require`, then invoking `bin/tapioca gem yard`, which I attempted to do in these commits:
https://github.com/dduugg/yard-sorbet/pull/103/commits/9e00ecd7e14c5ce25defb10d1273c69d9dfd9569
https://github.com/dduugg/yard-sorbet/pull/103/commits/87171343b2e26c1a6a872d6ccd1513832db2a920
However, I'm still seeing the same errors when I attempt to invoke `srb tc`
What am I doing wrong?

