### PR TITLE
Check runtime ancestors used in annotations files

### DIFF
--- a/gem/lib/rbi-central/runtime/visitor.rb
+++ b/gem/lib/rbi-central/runtime/visitor.rb
@@ -34,12 +34,26 @@ module RBICentral
         loc = T.must(node.loc)
 
         case node
-        when RBI::Module, RBI::Class
-          @context.add_constant(node.fully_qualified_name, loc)
+        when RBI::Class
+          @context.add_class(node.fully_qualified_name, node.superclass_name, loc)
+        when RBI::Module
+          @context.add_module(node.fully_qualified_name, loc)
         when RBI::Const
           return if node.value.start_with?("type_member") || node.value.start_with?("type_template")
 
           @context.add_constant(node.fully_qualified_name, loc)
+        when RBI::Include
+          scope = node.parent_scope
+          scope_name = scope_name(scope)
+          node.names.each do |name|
+            @context.add_include(scope_name, name, loc)
+          end
+        when RBI::Extend
+          scope = node.parent_scope
+          scope_name = scope_name(scope)
+          node.names.each do |name|
+            @context.add_extend(scope_name, name, loc)
+          end
         when RBI::Method
           scope = node.parent_scope
           scope_name = scope_name(scope)

--- a/gem/test/rbi-central/runtime/context_test.rb
+++ b/gem/test/rbi-central/runtime/context_test.rb
@@ -6,74 +6,219 @@ require "test_helper"
 module RBICentral
   module Runtime
     class ContextTest < Test
-      def test_init_requires
-        gem = Gem.new(name: "gem")
-        context = Context.new(gem, "#{ANNOTATIONS_PATH}/gem.rbi")
-        context.write_test!
-        assert_includes(context.read(Context::TEST_NAME), <<~RB)
-          begin
-            require "gem"
-          rescue LoadError => e
-            $stderr.puts("Can't require `gem`")
-            $success = false
-          end
-        RB
+      def test_require_error
+        mock = MockGem.new(Dir.mktmpdir, "foo")
+        mock.gemspec!(mock.default_gemspec)
+        context = Context.new(mock.gem, "foo.rbi")
+        assert_messages(["Can't require `foo`"], context.run!)
       end
 
-      def test_init_requires_custom
-        gem = Gem.new(name: "gem", requires: ["dep2", "dep1"])
-        context = Context.new(gem, "#{ANNOTATIONS_PATH}/gem.rbi")
-        context.write_test!
-        assert_includes(context.read(Context::TEST_NAME), <<~RB)
-          begin
-            require "dep2"
-          rescue LoadError => e
-            $stderr.puts("Can't require `dep2`")
-            $success = false
-          end
-          begin
-            require "dep1"
-          rescue LoadError => e
-            $stderr.puts("Can't require `dep1`")
-            $success = false
+      def test_missing_constant
+        mock = MockGem.new(Dir.mktmpdir, "foo")
+        mock.gemspec!(mock.default_gemspec)
+        mock.write!("lib/foo.rb", <<~RB)
+          module Foo
+            module Bar; end
           end
         RB
+        context = Context.new(mock.gem, "gem.rbi")
+        visitor = Runtime::Visitor.new(context)
+        rbi_tree = RBI::Parser.parse_string(<<~RBI)
+          module Foo; end
+          module Foo::Bar; end
+          module Not::Found; end
+        RBI
+        visitor.visit(rbi_tree)
+        assert_messages(["Missing runtime constant `::Not::Found` (defined at `-:3:0-3:22`)"], context.run!)
       end
 
-      def test_add_constant
-        gem = Gem.new(name: "gem")
-        loc = RBI::Loc.new(file: "gem.rbi", begin_line: 1, begin_column: 2, end_line: 3, end_column: 4)
-        context = Context.new(gem, "#{ANNOTATIONS_PATH}/gem.rbi")
-        context.add_constant("Foo", loc)
-        context.write_test!
-        assert_includes(context.read(Context::TEST_NAME), <<~RB)
-          __rbi_repo_get_const("Foo", "gem.rbi:1:2-3:4")
+      def test_missing_method
+        mock = MockGem.new(Dir.mktmpdir, "foo")
+        mock.gemspec!(mock.default_gemspec)
+        mock.write!("lib/foo.rb", <<~RB)
+          module Foo
+            def foo; end
+            class Bar
+              def self.foo; end
+            end
+          end
         RB
+        context = Context.new(mock.gem, "gem.rbi")
+        visitor = Runtime::Visitor.new(context)
+        rbi_tree = RBI::Parser.parse_string(<<~RBI)
+          module Foo
+            def foo; end
+            def bar; end
+          end
+
+          class Foo::Bar
+            def self.foo; end
+            def self.baz; end
+          end
+        RBI
+        visitor.visit(rbi_tree)
+        assert_messages([
+          "Missing runtime method `::Foo#bar` (defined at `-:3:2-3:14`)",
+          "Missing runtime method `::Foo::Bar.baz` (defined at `-:8:2-8:19`)",
+        ], context.run!)
       end
 
-      def test_add_method
-        gem = Gem.new(name: "gem")
-        loc = RBI::Loc.new(file: "gem.rbi", begin_line: 1, begin_column: 2, end_line: 3, end_column: 4)
-        context = Context.new(gem, "#{ANNOTATIONS_PATH}/gem.rbi")
-        context.add_method("Foo", "foo", loc, allow_missing: true, singleton: true)
-        context.add_method("Foo", "bar", loc, allow_missing: true, singleton: false)
-        context.write_test!
-        assert_includes(context.read(Context::TEST_NAME), <<~RB)
-          __rbi_repo_get_method(
-            "Foo",
-            "foo",
-            "gem.rbi:1:2-3:4",
-            singleton: true,
-            allow_missing: true
-          )
-          __rbi_repo_get_method(
-            "Foo",
-            "bar",
-            "gem.rbi:1:2-3:4",
-            singleton: false,
-            allow_missing: true
-          )
+      def test_wrong_kind
+        mock = MockGem.new(Dir.mktmpdir, "foo")
+        mock.gemspec!(mock.default_gemspec)
+        mock.write!("lib/foo.rb", <<~RB)
+          module Foo; end
+          class Bar; end
+          class Baz; end
         RB
+        context = Context.new(mock.gem, "gem.rbi")
+        rbi_tree = RBI::Parser.parse_string(<<~RBI)
+          class Foo; end
+          module Bar; end
+          class Baz; end
+        RBI
+        visitor = Runtime::Visitor.new(context)
+        visitor.visit(rbi_tree)
+        assert_messages([
+          "Runtime constant `::Foo` is not a class (defined at `-:1:0-1:14`)",
+          "Runtime constant `::Bar` is not a module (defined at `-:2:0-2:15`)",
+        ], context.run!)
+      end
+
+      def test_wrong_class_parent
+        mock = MockGem.new(Dir.mktmpdir, "foo")
+        mock.gemspec!(mock.default_gemspec)
+        mock.write!("lib/foo.rb", <<~RB)
+          class Foo; end
+          class Bar < Foo; end
+        RB
+        context = Context.new(mock.gem, "gem.rbi")
+        rbi_tree = RBI::Parser.parse_string(<<~RBI)
+          class Foo < Integer; end
+          class Foo < Object; end
+          class Foo; end
+          class Bar < Integer; end
+          class Bar < Foo; end
+          class Bar; end
+        RBI
+        visitor = Runtime::Visitor.new(context)
+        visitor.visit(rbi_tree)
+        assert_messages([
+          "Runtime constant `::Foo` is not a subclass of `Integer` found `Object` (defined at `-:1:0-1:24`)",
+          "Runtime constant `::Bar` is not a subclass of `Integer` found `Foo` (defined at `-:4:0-4:24`)",
+        ], context.run!)
+      end
+
+      def test_wrong_includes
+        mock = MockGem.new(Dir.mktmpdir, "foo")
+        mock.gemspec!(mock.default_gemspec)
+        mock.write!("lib/foo.rb", <<~RB)
+          module Mixin1; end
+          module Mixin2; end
+
+          module Foo
+            include Mixin1
+          end
+
+          module Bar
+            include Mixin2
+          end
+        RB
+        context = Context.new(mock.gem, "gem.rbi")
+        rbi_tree = RBI::Parser.parse_string(<<~RBI)
+          module Foo
+            include Mixin1, Mixin2
+            include Kernel
+          end
+
+          module Bar
+            include Mixin2
+          end
+        RBI
+        visitor = Runtime::Visitor.new(context)
+        visitor.visit(rbi_tree)
+        assert_messages([
+          "Runtime constant `::Foo` does not include `Mixin2` (defined at `-:2:2-2:24`)",
+          "Runtime constant `::Foo` does not include `Kernel` (defined at `-:3:2-3:16`)",
+        ], context.run!)
+      end
+
+      def test_wrong_extends
+        mock = MockGem.new(Dir.mktmpdir, "foo")
+        mock.gemspec!(mock.default_gemspec)
+        mock.write!("lib/foo.rb", <<~RB)
+          module Mixin1; end
+          module Mixin2; end
+
+          module Foo
+            extend Mixin1
+          end
+
+          module Bar
+            extend Mixin2
+          end
+        RB
+        context = Context.new(mock.gem, "gem.rbi")
+        rbi_tree = RBI::Parser.parse_string(<<~RBI)
+          module Foo
+            extend Mixin1, Mixin2
+            extend Kernel
+          end
+
+          module Bar
+            extend Mixin2
+          end
+        RBI
+        visitor = Runtime::Visitor.new(context)
+        visitor.visit(rbi_tree)
+        assert_messages([
+          "Runtime constant `::Foo` does not extend `Mixin2` (defined at `-:2:2-2:23`)",
+        ], context.run!)
+      end
+
+      def test_can_use_sorbet_runtime
+        mock = MockGem.new(Dir.mktmpdir, "foo")
+        mock.gemspec!(mock.default_gemspec)
+        mock.write!("#{mock.name}.gemspec", <<~RB)
+          Gem::Specification.new do |spec|
+            spec.name          = "#{mock.name}"
+            spec.version       = "0.1.1"
+            spec.authors       = ["Test"]
+            spec.email         = ["test@shopify.com"]
+            spec.summary       = "Some description"
+            spec.require_paths = ["lib"]
+            spec.files         = Dir.glob("lib/**/*.rb")
+
+            spec.add_runtime_dependency("sorbet-runtime", ">= 0.5.10109")
+          end
+        RB
+        mock.write!("lib/foo.rb", <<~RB)
+          require "sorbet-runtime"
+
+          module Foo
+            extend T::Sig
+            extend T::Helpers
+            extend T::Generic
+
+            def foo; end
+          end
+        RB
+        context = Context.new(mock.gem, "gem.rbi")
+        rbi_tree = RBI::Parser.parse_string(<<~RBI)
+          module Foo
+            extend T::Sig
+            extend T::Helpers
+            extend T::Generic
+
+            sig {returns(T.self_type)}
+            def foo; end
+
+            def bar; end
+          end
+        RBI
+        visitor = Runtime::Visitor.new(context)
+        visitor.visit(rbi_tree)
+        assert_messages(["Missing runtime method `::Foo#bar` (defined at `-:9:2-9:14`)"], context.run!)
       end
     end
   end

--- a/index.json
+++ b/index.json
@@ -109,7 +109,9 @@
       "minitest"
     ],
     "requires": [
-      "minitest/test"
+      "minitest/test",
+      "webmock/api",
+      "webmock/minitest"
     ]
   }
 }

--- a/rbi/annotations/actionview.rbi
+++ b/rbi/annotations/actionview.rbi
@@ -3,7 +3,7 @@
 module ActionView
   TemplateError = T.type_alias { Template::Error }
 
-  class MissingTemplate < ActionViewError
+  class MissingTemplate < ActionView::ActionViewError
     sig { returns(String) }
     def path; end
   end

--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -4,7 +4,3 @@ class ActiveRecord::Schema
   sig {params(info: T::Hash[T.untyped, T.untyped], blk: T.proc.bind(ActiveRecord::Schema).void).void}
   def self.define(info = nil, &blk); end
 end
-
-class ActiveRecord::Migration::Current < ActiveRecord::Migration
-  include ActiveRecord::ConnectionAdapters::SchemaStatements
-end

--- a/rbi/annotations/lhm-shopify.rbi
+++ b/rbi/annotations/lhm-shopify.rbi
@@ -69,7 +69,7 @@ class Lhm::Printer::Base
   def initialize; end
 end
 
-class Lhm::Printer::Percentage < Lhm::Printer::Base
+class Lhm::Printer::Percentage
   sig { void }
   def end; end
 

--- a/rbi/annotations/parse-cron.rbi
+++ b/rbi/annotations/parse-cron.rbi
@@ -2,8 +2,6 @@
 
 # Parses cron expressions and computes the next occurence of the "job"
 class CronParser
-  extend T::Generic
-
   SYMBOLS = T.let({}, T::Hash[String, String])
   SUBELEMENT_REGEX = T.let(%r{}, Regexp)
 
@@ -33,22 +31,22 @@ class CronParser
   sig { params(year: Integer, month: Integer).returns([T::Set[Integer], T::Array[Integer]]) }
   def interpolate_weekdays_without_cache(year, month); end
 
-  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(Integer) }
+  sig { params(t: InternalTime, dir: Symbol).returns(Integer) }
   def nudge_year(t, dir = :next); end
 
-  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(Integer) }
+  sig { params(t: InternalTime, dir: Symbol).returns(Integer) }
   def nudge_month(t, dir = :next); end
 
-  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(T::Boolean) }
+  sig { params(t: InternalTime, dir: Symbol).returns(T::Boolean) }
   def date_valid?(t, dir = :next); end
 
-  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol, can_nudge_month: T::Boolean).returns(T.nilable(Integer)) }
+  sig { params(t: InternalTime, dir: Symbol, can_nudge_month: T::Boolean).returns(T.nilable(Integer)) }
   def nudge_date(t, dir = :next, can_nudge_month = true); end
 
-  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(T.nilable(Integer)) }
+  sig { params(t: InternalTime, dir: Symbol).returns(T.nilable(Integer)) }
   def nudge_hour(t, dir = :next); end
 
-  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(T.nilable(Integer)) }
+  sig { params(t: InternalTime, dir: Symbol).returns(T.nilable(Integer)) }
   def nudge_minute(t, dir = :next); end
 
   sig { returns(T::Hash[Symbol, [T::Set[Integer], T::Array[Integer], String]]) }
@@ -71,8 +69,6 @@ end
 
 # internal "mutable" time representation
 class CronParser::InternalTime
-  extend T::Generic
-
   sig { returns(Integer) }
   attr_accessor :year, :month, :day, :hour, :min
 

--- a/rbi/annotations/rainbow.rbi
+++ b/rbi/annotations/rainbow.rbi
@@ -15,7 +15,7 @@ module Rainbow
     sig { params(hex: String).returns([Integer, Integer, Integer]) }
     def self.parse_hex_color(hex); end
 
-    class Indexed < Color
+    class Indexed < Rainbow::Color
       sig { returns(Integer) }
       attr_reader :num
 
@@ -26,7 +26,7 @@ module Rainbow
       def codes; end
     end
 
-    class Named < Indexed
+    class Named < Rainbow::Color::Indexed
       NAMES = T.let(nil, T::Hash[Symbol, Integer])
 
       sig { params(ground: Symbol, name: Symbol).void }
@@ -39,7 +39,7 @@ module Rainbow
       def self.valid_names; end
     end
 
-    class RGB < Indexed
+    class RGB < Rainbow::Color::Indexed
       sig { returns(Integer) }
       attr_reader :r, :g, :b
 
@@ -53,8 +53,8 @@ module Rainbow
       def self.to_ansi_domain(value); end
     end
 
-    class X11Named < RGB
-      include X11ColorNames
+    class X11Named < Rainbow::Color::RGB
+      include Rainbow::X11ColorNames
 
       sig { returns(T::Array[Symbol]) }
       def self.color_names; end


### PR DESCRIPTION
### Type of Change

- [ ] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [x] Other: Ci

### Changes

When running runtime checks we also check that super classes and modules included/extended in the RBI file reflect the runtime behavior.

This allowed me to find a few errors in the current set of annotations (see discussions below).

Closes https://github.com/Shopify/rbi-central/issues/81.