### PR TITLE
Allow disabling gem checks with `--no-gem`

### DIFF
--- a/gem/lib/rbi-central/cli/helper.rb
+++ b/gem/lib/rbi-central/cli/helper.rb
@@ -52,7 +52,7 @@ module RBICentral
         end
 
         if checks.changed_files.any? { |file| file.match?(%r{^gem/.*}) }
-          checks.gem_tests = true
+          checks.gem_tests &= true
           checks.index &= true
           checks.rubocop &= true
           checks.rubygems &= true


### PR DESCRIPTION
### Type of Change

- [ ] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [x] Other: CI

### Changes

Right now, if a file under `gem/` was modified we always run the gem checks when running `repo check`.

This PR fixes the check selection to allow a default at `false` when passing `--no-gem`.