### PR TITLE
`Rails.application.config` is untyped

### DIFF
--- a/rbi/annotations/railties.rbi
+++ b/rbi/annotations/railties.rbi
@@ -30,21 +30,9 @@ class Rails::Application < ::Rails::Engine
   def config; end
 end
 
-module Rails::Command::Behavior
-  mixes_in_class_methods ::Rails::Command::Behavior::ClassMethods
-end
-
 class Rails::Engine < ::Rails::Railtie
   sig { returns(ActionDispatch::Routing::RouteSet) }
   def routes(&block); end
-end
-
-module Rails::Generators::Migration
-  mixes_in_class_methods ::Rails::Generators::Migration::ClassMethods
-end
-
-module Rails::Initializable
-  mixes_in_class_methods ::Rails::Initializable::ClassMethods
 end
 
 class Rails::Railtie

--- a/rbi/annotations/railties.rbi
+++ b/rbi/annotations/railties.rbi
@@ -26,7 +26,7 @@ module Rails
 end
 
 class Rails::Application < ::Rails::Engine
-  sig { returns(Rails::Application::Configuration) }
+  sig { returns(T.untyped) }
   def config; end
 end
 


### PR DESCRIPTION
This method returns a hash like object that responds to any method,
if there is a key with that method name.

Since we can't know statically what methods it responds to, we should
not be returning a `Configuration` object.

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: rails
* Gem version: all
* Gem source: https://github.com/rails/rails/blob/39413de44c0e2c0dd2d964be5985b03d8f968a7b/railties/lib/rails/railtie/configuration.rb#L90
