### PR TITLE
Include SchemaStatements under ActiveRecord::Migration

### DIFF
--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -4,3 +4,8 @@ class ActiveRecord::Schema
   sig {params(info: T::Hash[T.untyped, T.untyped], blk: T.proc.bind(ActiveRecord::Schema).void).void}
   def self.define(info = nil, &blk); end
 end
+
+class ActiveRecord::Migration
+  # @shim: Methods on migration are delegated to `SchemaStatements` using `method_missing`
+  include ActiveRecord::ConnectionAdapters::SchemaStatements
+end


### PR DESCRIPTION
Exposes migrations methods that are dynamically mixed in. This is an existing workaround for apps that have migrations marked `typed: true`: https://github.com/Shopify/tapioca/issues/696#issuecomment-1145271363

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: <!-- Add the name of the gem you have a problem with here --> rails
* Gem source: <!-- Link relevant source code from the gem for the problem you have --> https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L606
