### PR TITLE
Adds shim for `sorbet-coerce`

### DIFF
--- a/index.json
+++ b/index.json
@@ -100,6 +100,8 @@
       "sidekiq/web"
     ]
   },
+  "sorbet-coerce": {
+  },
   "state_machines": {
   },
   "stripe": {

--- a/rbi/annotations/sorbet-coerce.rbi
+++ b/rbi/annotations/sorbet-coerce.rbi
@@ -1,0 +1,9 @@
+# typed: strict
+
+module TypeCoerce
+  Elem = type_member
+
+  # @shim: at runtime, this is delegated to TypeCoerce::Converter; the use-case looks like: TypeCoerce[Klass].new.from(...)
+  sig { params(args: T.untyped, raise_coercion_error: T.nilable(T::Boolean), coerce_empty_to_nil: T::Boolean).returns(Elem) }
+  def from(args, raise_coercion_error: nil, coerce_empty_to_nil: false); end
+end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

I'm an interim maintainer for  [`sorbet-coerce`](https://github.com/chanzuckerberg/sorbet-coerce) and am adding a shim! This is what we use internally @chanzuckerberg. This shim is valid for the latest version of `sorbet-coerce` and works across various Tapioca/Sorbet versions.

I did want to ask about including `Elem = type member`. In our internal codebase, including that line causes a duplicate definition of the `type_member`; however, if I remove that line, then `bundle exec repo check static sorbet-coerce` fails with 

```console
$ bundle exec repo check static sorbet-coerce 
Error: rbi/annotations/sorbet-coerce.rbi:5: Unable to resolve constant Elem https://srb.help/5002
     5 |  sig { params(args: T.untyped, raise_coercion_error: T.nilable(T::Boolean), coerce_empty_to_nil: T::Boolean).returns(Elem) }
```

which locally no longer exists in the file, but should be defined by Tapioca's generated file from `bin/tapioca gems`. How should I proceed here?

Note: I used a slightly different definition for sorbet-coerce on sorbet-typed: https://github.com/sorbet/sorbet-typed/pull/396.
