### PR TITLE
Improve ActiveRecord::Migration types by including DatabaseStatements module.

### DIFF
--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -8,5 +8,6 @@ end
 class ActiveRecord::Migration
   # @shim: Methods on migration are delegated to `SchemaStatements` using `method_missing`
   include ActiveRecord::ConnectionAdapters::SchemaStatements
+  # @shim: Methods on migration are delegated to `DatabaseaStatements` using `method_missing`
   include ActiveRecord::ConnectionAdapters::DatabaseStatements
 end

--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -8,4 +8,5 @@ end
 class ActiveRecord::Migration
   # @shim: Methods on migration are delegated to `SchemaStatements` using `method_missing`
   include ActiveRecord::ConnectionAdapters::SchemaStatements
+  include ActiveRecord::ConnectionAdapters::DatabaseStatements
 end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: activerecord
* Gem version: 7.0.4
* Gem source: [This inclusion was not represented](https://github.com/rails/rails/blob/fbc4dff57866ac35e000b86a51afe28ec1606a8f/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L33)
* Gem API doc: [the `execute` method was not being understood in migrations](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-execute)
* Tapioca version: 0.10.1
* Sorbet version: 0.5.10439

There are various methods that were missing due to the lack of the DatabaseStatements module.

You can see the inclusion here in the Rails repo:
https://github.com/rails/rails/blob/fbc4dff57866ac35e000b86a51afe28ec1606a8f/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L33