### PR TITLE
Add activestorage.rbi

### DIFF
--- a/index.json
+++ b/index.json
@@ -24,6 +24,16 @@
       "active_record"
     ]
   },
+  "activestorage": {
+    "dependencies": [
+      "rails"
+    ],
+    "requires": [
+      "rails",
+      "active_storage/engine",
+      "active_storage"
+    ]
+  },
   "activesupport": {
     "requires": [
       "active_support",

--- a/rbi/annotations/activestorage.rbi
+++ b/rbi/annotations/activestorage.rbi
@@ -1,0 +1,15 @@
+# typed: strict
+
+class ActiveStorage::Attached::One
+  # @shim: Methods on Attached::One are delegated to `ActiveStorage::Blob` through `ActiveStorage::Attachment` using `method_missing`
+  include ActiveStorage::Blob::Analyzable
+  include ActiveStorage::Blob::Identifiable
+  include ActiveStorage::Blob::Representable
+end
+
+class ActiveStorage::Attached::Many
+  # @shim: Methods on Attached::Many are delegated to `ActiveStorage::Blob` through `ActiveStorage::Attachment` using `method_missing`
+  include ActiveStorage::Blob::Analyzable
+  include ActiveStorage::Blob::Identifiable
+  include ActiveStorage::Blob::Representable
+end

--- a/rbi/annotations/activestorage.rbi
+++ b/rbi/annotations/activestorage.rbi
@@ -3,13 +3,17 @@
 class ActiveStorage::Attached::One
   # @shim: Methods on Attached::One are delegated to `ActiveStorage::Blob` through `ActiveStorage::Attachment` using `method_missing`
   include ActiveStorage::Blob::Analyzable
+  # @shim: Methods on Attached::One are delegated to `ActiveStorage::Blob` through `ActiveStorage::Attachment` using `method_missing`
   include ActiveStorage::Blob::Identifiable
+  # @shim: Methods on Attached::One are delegated to `ActiveStorage::Blob` through `ActiveStorage::Attachment` using `method_missing`
   include ActiveStorage::Blob::Representable
 end
 
 class ActiveStorage::Attached::Many
   # @shim: Methods on Attached::Many are delegated to `ActiveStorage::Blob` through `ActiveStorage::Attachment` using `method_missing`
   include ActiveStorage::Blob::Analyzable
+  # @shim: Methods on Attached::Many are delegated to `ActiveStorage::Blob` through `ActiveStorage::Attachment` using `method_missing`
   include ActiveStorage::Blob::Identifiable
+  # @shim: Methods on Attached::Many are delegated to `ActiveStorage::Blob` through `ActiveStorage::Attachment` using `method_missing`
   include ActiveStorage::Blob::Representable
 end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: activestorage
* Gem version: 7.0.4
* Gem source: https://github.com/rails/rails/blob/v7.0.4/activestorage/lib/active_storage/attached/one.rb#L25
* Gem API doc: https://api.rubyonrails.org/classes/ActiveStorage/Blob/Representable.html#method-i-variant
* Tapioca version: 0.10.1
* Sorbet version: 0.5.10439

Various methods were not being handled correctly (e.g. `variant`) for Rails models that were using ActiveStorage. This fixes many of those issues.