### PR TITLE
Add on_load method signature for ActiveSupport

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -1,5 +1,10 @@
 # typed: strict
 
+module ActiveSupport
+  sig { params(kind: Symbol, blk: T.proc.bind(T.untyped).void).void }
+  def self.on_load(kind, &blk); end
+end
+
 module ActiveSupport::Testing::Declarative
   sig { params(name: String, block: T.proc.bind(T.untyped).void).void }
   def test(name, &block); end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: activesupport
* Gem version: 7.0.4
* Gem source: https://github.com/rails/rails/blob/8015c2c2cf5c8718449677570f372ceb01318a32/activesupport/lib/active_support/lazy_load_hooks.rb#L58
* Gem API doc: https://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html#method-i-on_load
* Tapioca version: 0.10.1
* Sorbet version: 0.5.10439

For example, this code that's generated by default in Rails fails typechecking without this signature because it doesn't know where `wrap_parameters` is supposed to come from:

```rb
# Be sure to restart your server when you modify this file.

# This file contains settings for ActionController::ParamsWrapper which
# is enabled by default.

# Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
ActiveSupport.on_load(:action_controller) do
  wrap_parameters format: [:json]
end

# To enable root element in JSON for ActiveRecord objects.
# ActiveSupport.on_load(:active_record) do
#   self.include_root_in_json = true
# end
```

So we avoid this problem by just marking the block as untyped.