### PR TITLE
Add RBI file for paper_trail gem

### DIFF
--- a/index.json
+++ b/index.json
@@ -59,6 +59,9 @@
     ]
   },
   "paper_trail": {
+    "requires": [
+      "active_record"
+    ]
   },
   "parse-cron": {
   },

--- a/index.json
+++ b/index.json
@@ -58,6 +58,8 @@
       "mocha/api"
     ]
   },
+  "paper_trail": {
+  },
   "parse-cron": {
   },
   "pundit": {

--- a/rbi/annotations/paper_trail.rbi
+++ b/rbi/annotations/paper_trail.rbi
@@ -1,0 +1,13 @@
+# typed: strict
+
+module PaperTrail::Model::ClassMethods
+  sig { params(options: T.nilable(T::Hash[Symbol, T.untyped])).void }
+  def has_paper_trail(options = {}); end
+
+  sig { returns(T.untyped) }
+  def paper_trail; end
+end
+
+class ActiveRecord::Base
+  extend PaperTrail::Model::ClassMethods
+end


### PR DESCRIPTION
PaperTrail adds methods to ActiveRecord models at runtime. Adding this RBI informs Sorbet of these methods.

### Type of Change

<!-- Select the option that best reflect your changes -->

- [x] Add RBI for a new gem

### Changes

<!-- Include the following information with your PR -->

* Gem name: PaperTrail (paper_trail)
* Gem version: 13.0.0
* Gem source: https://github.com/paper-trail-gem/paper_trail
* Gem API doc: <!-- Link relevant API doc from the gem for the problem you have -->
* Gem relevant source files: [1](https://github.com/paper-trail-gem/paper_trail/blob/49659e8a0c4cb0c80aeab344b7b434de7f057c88/lib/paper_trail/frameworks/active_record.rb), [2](https://github.com/paper-trail-gem/paper_trail/blob/master/lib/paper_trail/frameworks/active_record.rb)
* Tapioca version: 0.10.2
* Sorbet version: 0.5.10439
