### PR TITLE
Fix aws-sdk-acm runtime check

### DIFF
--- a/index.json
+++ b/index.json
@@ -31,6 +31,9 @@
     ]
   },
   "aws-sdk-acm": {
+    "dependencies": [
+      "nokogiri"
+    ]
   },
   "bencode": {
   },


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [x] Other: The aws-sdk-acm gem requires a compatible XML library to be installed.
