### PR TITLE
Allow @method_missing annotation for singleton methods

### DIFF
--- a/gem/lib/rbi-central/runtime/context.rb
+++ b/gem/lib/rbi-central/runtime/context.rb
@@ -203,7 +203,7 @@ module RBICentral
               const.instance_method("\#{method_name}")
             end
           rescue NameError => e
-            if const && !singleton && __rbi_repo_respond_to_method_missing?(const)
+            if const && __rbi_repo_respond_to_method_missing?(const, singleton: singleton)
               return if allow_missing
 
               $stderr.puts("Missing runtime method `\#{recv_name}\#{singleton ? "." : "#"}\#{method_name}` (defined at `\#{rbi_loc}`)")
@@ -217,8 +217,12 @@ module RBICentral
             nil
           end
 
-          def __rbi_repo_respond_to_method_missing?(const)
-            method = const.instance_method(:method_missing)
+          def __rbi_repo_respond_to_method_missing?(const, singleton:)
+            method = if singleton
+              const.method(:method_missing)
+            else
+              const.instance_method(:method_missing)
+            end
             !/\\(BasicObject\\)/.match?(method.to_s)
           rescue NameError => e
             false

--- a/gem/lib/rbi-central/runtime/context.rb
+++ b/gem/lib/rbi-central/runtime/context.rb
@@ -219,7 +219,7 @@ module RBICentral
 
           def __rbi_repo_respond_to_method_missing?(const, singleton:)
             method = if singleton
-              const.method(:method_missing)
+              const.singleton_method(:method_missing)
             else
               const.instance_method(:method_missing)
             end

--- a/gem/test/rbi-central/runtime/context_test.rb
+++ b/gem/test/rbi-central/runtime/context_test.rb
@@ -63,6 +63,31 @@ module RBICentral
         ], context.run!)
       end
 
+      def test_annotated_method_missing
+        mock = MockGem.new(Dir.mktmpdir, "foo")
+        mock.gemspec!(mock.default_gemspec)
+        mock.write!("lib/foo.rb", <<~RB)
+          class Foo
+            def method_missing(*); end
+          end
+        RB
+        context = Context.new(mock.gem, "gem.rbi")
+        visitor = Runtime::Visitor.new(context)
+        rbi_tree = RBI::Parser.parse_string(<<~RBI)
+          class Foo
+            # @method_missing: some description
+            def bar; end
+            def baz; end
+          end
+        RBI
+        visitor.visit(rbi_tree)
+        assert_messages([
+          "Missing runtime method `::Foo#baz` (defined at `-:4:2-4:14`)\n" \
+            "Note: `baz` could be delegated to :method_missing but the RBI " \
+            "definition isn't annotated with `@method_missing`.",
+        ], context.run!)
+      end
+
       def test_wrong_kind
         mock = MockGem.new(Dir.mktmpdir, "foo")
         mock.gemspec!(mock.default_gemspec)


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [x] Other: Fixes #118.

This PR ensures the `@method_missing` annotation works on singleton methods by validating that the `method_missing` method is defined.