### PR TITLE
Remove duplicated mixins from annotations

### DIFF
--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -1,17 +1,5 @@
 # typed: strict
 
-module AbstractController::Helpers
-  mixes_in_class_methods(::AbstractController::Helpers::ClassMethods)
-end
-
-module AbstractController::UrlFor
-  mixes_in_class_methods(::AbstractController::UrlFor::ClassMethods)
-end
-
-class ActionController::Base < ::ActionController::Metal
-  include(::ActiveSupport::Rescuable)
-end
-
 class ActionController::API
   MODULES = T.let(T.unsafe(nil), T::Array[T.untyped])
 end
@@ -19,10 +7,6 @@ end
 module ActionController::Flash::ClassMethods
   sig { params(types: Symbol).void }
   def add_flash_types(*types); end
-end
-
-module ActionController::Helpers
-  mixes_in_class_methods(::ActionController::Helpers::ClassMethods)
 end
 
 module ActionController::Helpers::ClassMethods
@@ -226,14 +210,6 @@ class ActionController::Parameters
   def values_at(*keys); end
 end
 
-module ActionController::Renderers
-  mixes_in_class_methods(::ActionController::Renderers::ClassMethods)
-end
-
-module ActionController::Rendering
-  mixes_in_class_methods(::ActionController::Rendering::ClassMethods)
-end
-
 module ActionController::RequestForgeryProtection
   private
 
@@ -255,8 +231,6 @@ module ActionController::StrongParameters
 end
 
 module ActionDispatch::Http::Parameters
-  mixes_in_class_methods ::ActionDispatch::Http::Parameters::ClassMethods
-
   sig { returns(ActionController::Parameters) }
   def parameters(); end
 

--- a/rbi/annotations/graphql.rbi
+++ b/rbi/annotations/graphql.rbi
@@ -8,9 +8,6 @@ module GraphQL
 end
 
 class GraphQL::Backtrace
-  include ::Enumerable
-  extend ::Forwardable
-
   Elem = type_member {{fixed: T.untyped}}
 end
 
@@ -27,21 +24,13 @@ class GraphQL::Schema::InputObject < ::GraphQL::Schema::Member
 end
 
 class GraphQL::Schema::Object < ::GraphQL::Schema::Member
-  extend ::GraphQL::Schema::Member::HasFields
-
   sig { returns(GraphQL::Query::Context) }
   def context; end
 end
 
 class GraphQL::Schema::Resolver
-  extend ::GraphQL::Schema::Member::BaseDSLMethods
-
   sig { returns(GraphQL::Query::Context) }
   def context; end
-end
-
-class GraphQL::Schema::Member
-  extend ::GraphQL::Schema::Member::BaseDSLMethods
 end
 
 module GraphQL::Schema::Member::HasFields
@@ -63,12 +52,4 @@ end
 module GraphQL::Schema::Interface
   mixes_in_class_methods ::GraphQL::Schema::Member::BaseDSLMethods
   mixes_in_class_methods ::GraphQL::Schema::Member::HasFields
-end
-
-class GraphQL::Schema::Mutation < ::GraphQL::Schema::Resolver
-  extend ::GraphQL::Schema::Member::HasFields
-end
-
-class GraphQL::Schema::Subscription < ::GraphQL::Schema::Resolver
-  extend ::GraphQL::Schema::Member::HasFields
 end

--- a/rbi/annotations/sidekiq.rbi
+++ b/rbi/annotations/sidekiq.rbi
@@ -29,20 +29,14 @@ class Sidekiq::Launcher
 end
 
 class Sidekiq::Middleware::Chain
-  include ::Enumerable
-
   Elem = type_member {{fixed: T.untyped}}
 end
 
 class Sidekiq::ProcessSet
-  include ::Enumerable
-
   Elem = type_member {{fixed: Sidekiq::Process}}
 end
 
 class Sidekiq::Queue
-  include ::Enumerable
-
   Elem = type_member {{fixed: Sidekiq::Job}}
 
   sig { returns(T::Boolean) }
@@ -61,14 +55,10 @@ class Sidekiq::ScheduledSet < ::Sidekiq::JobSet
 end
 
 class Sidekiq::SortedSet
-  include ::Enumerable
-
   Elem = type_member {{fixed: Sidekiq::SortedEntry}}
 end
 
 module Sidekiq::Worker
-  mixes_in_class_methods ::Sidekiq::Worker::ClassMethods
-
   sig { returns(String) }
   def jid; end
 end
@@ -85,7 +75,5 @@ module Sidekiq::Worker::ClassMethods
 end
 
 class Sidekiq::WorkSet
-  include ::Enumerable
-
   Elem = type_member {{fixed: T.untyped}}
 end


### PR DESCRIPTION
Those are already generated by Tapioca and are caught by `check-shims` since https://github.com/Shopify/tapioca/pull/1077 was released.
