### PR TITLE
Change return type for ActionMailer mail method

### DIFF
--- a/rbi/annotations/actionmailer.rbi
+++ b/rbi/annotations/actionmailer.rbi
@@ -1,6 +1,6 @@
 # typed: strict
 
 class ActionMailer::Base
-  sig { params(headers: T.untyped).returns(Mail::Message) }
+  sig { params(headers: T.untyped, block: T.nilable(T.proc.void)).returns(Mail::Message) }
   def mail(headers = nil, &block); end
 end

--- a/rbi/annotations/actionmailer.rbi
+++ b/rbi/annotations/actionmailer.rbi
@@ -1,6 +1,6 @@
 # typed: strict
 
 class ActionMailer::Base
-  sig { params(headers: T.untyped).returns(ActionMailer::MessageDelivery) }
+  sig { params(headers: T.untyped).returns(Mail::Message) }
   def mail(headers = nil, &block); end
 end


### PR DESCRIPTION
### Type of Change

PR for this issue: https://github.com/Shopify/rbi-central/issues/123.

This was updated in sorbet/sorbet-typed: https://github.com/sorbet/sorbet-typed/pull/399

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: action_mailer
* Gem version: 7.0.4
* Gem source: https://github.com/rails/rails/tree/main/actionmailer/lib/action_mailer
* Gem API doc: https://guides.rubyonrails.org/action_mailer_basics.html
* Tapioca version: 0.10.2
* Sorbet version: 0.5.10470
