### PR TITLE
Add T::Boolean for blank? and present? on Object

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -39,7 +39,10 @@ class ActiveSupport::TestCase
   def self.test(name, &block); end
 end
 
-class String
+class Object
   sig { returns(T::Boolean) }
   def blank?; end
+
+  sig { returns(T::Boolean) }
+  def present?; end
 end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

This adds the `T::Boolean` signature for `blank?` and `present?`. We initially had `String`, but I don't see any reason to not just put it on `Object` as that is where Rails defines it anyway. Since we don't have to worry about the specific implementations, just the signatures, that seems sufficient/efficient.

[This can be seen on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aclass%20Array%0A%20%20alias_method%20%3Ablank%3F%2C%20%3Aempty%3F%0A%0A%20%20def%20present%3F%0A%20%20%20%20!blank%3F%0A%20%20end%0Aend%0A%0Aextend%20T%3A%3ASig%0A%0Asig%20%7B%20returns%28T%3A%3AArray%5BInteger%5D%29%20%7D%0Adef%20stuff%0A%20%20%5B%5D%0Aend%0A%0Asig%20%7B%20returns%28T%3A%3ABoolean%29%20%7D%0Adef%20do_stuff_present%3F%0A%20%20stuff.present%3F%0Aend%0A%0Asig%20%7B%20returns%28T%3A%3ABoolean%29%20%7D%0Adef%20do_stuff_any%3F%0A%20%20stuff.any%3F%28%26%3Aeven%3F%29%0Aend%0A%0Asig%20%7B%20returns%28T%3A%3ABoolean%29%20%7D%0Adef%20do_stuff_present_and_even%3F%0A%20%20stuff.present%3F%20%26%26%20stuff.any%3F%28%26%3Aeven%3F%29%0Aend).

Technically not using `activesupport` but you get the idea.

`array.present? && array.any?(&:method)` will claim that is returns `T.nilable(T::Boolean)` even though each method individually returns a boolean.

* Gem name: `activesupport`
* Gem source: https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/object/blank.rb
* Gem API doc: https://api.rubyonrails.org/classes/Object.html#method-i-blank-3F
* Tapioca version: v0.10.2
* Sorbet version: 0.5.10488