### PR TITLE
Update RBI for mocha 2.0

### DIFF
--- a/rbi/annotations/mocha.rbi
+++ b/rbi/annotations/mocha.rbi
@@ -16,11 +16,12 @@ end
 class Mocha::Expectation
   sig do
     params(
-      expected_parameters: T.untyped,
+      expected_parameters_or_matchers: T.untyped,
+      _arg1: T.untyped,
       matching_block: T.nilable(T.proc.params(actual_parameters: T.untyped).void)
     ).returns(Mocha::Expectation)
   end
-  def with(*expected_parameters, &matching_block); end
+  def with(*expected_parameters_or_matchers, **_arg1, &matching_block); end
 
   sig { params(values: T.untyped).returns(Mocha::Expectation) }
   def returns(*values); end


### PR DESCRIPTION
### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

* Gem name: mocha
* Gem version: 2.0.2
* Gem source: https://github.com/freerange/mocha
* Gem API doc: https://github.com/freerange/mocha#usage
* Tapioca version: Tapioca v0.10.3
* Sorbet version: Sorbet typechecker 0.5.10559 git b5a80d8c764a77dba6409f40116121cd13294a10 debug_symbols=true clean=1

Additional notes:
- this fixes the signature to work with mocha 2.0.2, but it will likely break it for people still running mocha 1.x. I assume that the annotations in this repo are meant to work with the most recent version of their gems, but let me know if that's incorrect
- I'm not entirely sure why Tapioca generates the following signature for the `Mocha::Expectation#with` method:
    ```ruby
  def with(*expected_parameters_or_matchers, **_arg1, &matching_block); end
    ```
    The method is defined as follows in [mocha's source](https://github.com/freerange/mocha/blob/v2.0.2/lib/mocha/expectation.rb#L269):
    ```ruby
    def with(*expected_parameters_or_matchers, &matching_block)
    ```