### PR TITLE
Fix Lhm::Printer::Dot#notify signature

### DIFF
--- a/rbi/annotations/lhm.rbi
+++ b/rbi/annotations/lhm.rbi
@@ -91,8 +91,8 @@ class Lhm::Printer::Dot < Lhm::Printer::Base
   sig { void }
   def end; end
 
-  sig { params(lowest: T.nilable(Numeric), highest: T.nilable(Numeric)).void }
-  def notify(lowest = nil, highest = nil); end
+  sig { params(args: T.untyped).void }
+  def notify(*args); end
 end
 
 class Lhm::Migrator


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: lhm
* Gem version: latest
* Gem source: https://github.com/soundcloud/lhm/blob/50907121eee514649fa944fb300d5d8a64fa873e/lib/lhm/printer.rb#L45

The notify method accepts a `*` parameter only.