### PR TITLE
Update Ruby version in CI to 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
           bundler-cache: true
       - name: Check RBIs and index
         run: |

--- a/gem/.rubocop.yml
+++ b/gem/.rubocop.yml
@@ -7,7 +7,7 @@ require:
  - rubocop-sorbet
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   NewCops: disable
   SuggestExtensions: false
   Exclude:

--- a/gem/rbi-central.gemspec
+++ b/gem/rbi-central.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("tapioca", ">= 0.9.2")
   spec.add_dependency("thor", ">= 1.2.1")
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.1"
 end


### PR DESCRIPTION
Ruby 2.7 is almost at EOL; let's prioritize 3.1 for now.

Should unblock https://github.com/Shopify/rbi-central/pull/130