### PR TITLE
Add annotation for turbo-rails

### DIFF
--- a/index.json
+++ b/index.json
@@ -107,6 +107,14 @@
   },
   "stripe": {
   },
+  "turbo-rails": {
+    "dependencies": [
+      "actionpack"
+    ],
+    "requires": [
+      "action_dispatch"
+    ]
+  },
   "webmock": {
     "dependencies": [
       "minitest"

--- a/rbi/annotations/turbo-rails.rbi
+++ b/rbi/annotations/turbo-rails.rbi
@@ -1,0 +1,6 @@
+# typed: strict
+
+# workaround for https://github.com/Shopify/tapioca/issues/671
+
+module Turbo::Streams::ActionHelper
+end


### PR DESCRIPTION
### Type of Change

This is a tapioca limitation that should hit all users of `turbo-rails` so it can be part of `rbi-central` https://github.com/Shopify/tapioca/issues/671#issuecomment-1001048417

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: turbo-rails
* Gem version: 1.3.2
* Gem source: <!-- Link relevant source code from the gem for the problem you have -->
* Gem API doc: <!-- Link relevant API doc from the gem for the problem you have -->
* Tapioca version: Latest
* Sorbet version: <!-- Add the version of Sorbet you use -->
