### PR TITLE
Do not sign commits during tests

### DIFF
--- a/gem/test/test_helper.rb
+++ b/gem/test/test_helper.rb
@@ -40,7 +40,7 @@ module RBICentral
     sig { returns(Spoom::ExecResult) }
     def git_commit!
       git("add -A")
-      git("commit -m 'Update'")
+      git("-c commit.gpgsign=false commit -m 'Update'")
     end
 
     sig { params(name: String).returns(Spoom::ExecResult) }


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [x] Other: <!-- Provide additional information -->

### Changes

GPG signing clutters the test output and is probably slower. It's done by default in Shopify machines so I think it's worth disabling it in our tests.

Using https://git-scm.com/docs/git#Documentation/git.txt--cltnamegtltvaluegt
