### PR TITLE
Add more signatures to `ActionDispatch::IntegrationTest`

### DIFF
--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -250,15 +250,73 @@ module ActionDispatch::Integration::Runner
 end
 
 class ActionDispatch::IntegrationTest
-  # @method_missing: delegated to ActionDispatch::Integration::Runner
+  # The following methods are accessible on `IntegrationTest`
+  # through the following delegation chain:
+  # - `IntegrationTest` includes `IntegrationTest::Behavior`
+  # - `IntegrationTest::Behavior` includes `Integration::Runner`
+  # - `Integration::Runner#method_missing` delegates to `Integration::Session`
+  #
+  # Then `Integration::Session` either implements the methods
+  # directly or further delegates to `TestProcess` (included) or
+  # `TestResponse` / `Request` (via `delegate`).
+  #
+  # Cf. https://github.com/Shopify/rbi-central/pull/138 for more context.
+
+  # @method_missing: delegated to ActionDispatch::TestProcess
   sig { returns(ActionDispatch::Flash::FlashHash) }
   def flash; end
 
-  # @method_missing: delegated to ActionDispatch::Integration::Runner
+  # @method_missing: delegated to ActionDispatch::TestProcess
   sig { returns(ActionDispatch::Request::Session) }
   def session; end
 
-  private
+  # @method_missing: delegated to ActionDispatch::TestResponse
+  sig { returns(T.nilable(Integer)) }
+  def status; end
+
+  # @method_missing: delegated to ActionDispatch::TestResponse
+  sig { returns(T.nilable(String)) }
+  def status_message; end
+
+  # @method_missing: delegated to ActionDispatch::TestResponse
+  sig { returns(T.nilable(ActionDispatch::Response::Header)) }
+  def headers; end
+
+  # @method_missing: delegated to ActionDispatch::TestResponse
+  sig { returns(T.nilable(String)) }
+  def body; end
+
+  # @method_missing: delegated to ActionDispatch::TestResponse
+  sig { returns(T.nilable(T::Boolean)) }
+  def redirect?; end
+
+  # @method_missing: delegated to ActionDispatch::Request
+  sig { returns(T.nilable(String)) }
+  def path; end
+
+  # @method_missing: delegated to ActionDispatch::Integration::Session
+  sig { returns(String) }
+  def host; end
+
+  # @method_missing: delegated to ActionDispatch::Integration::Session
+  sig { params(host: String).returns(String) }
+  attr_writer :host
+
+  # @method_missing: delegated to ActionDispatch::Integration::Session
+  sig { returns(T.nilable(String)) }
+  attr_accessor :remote_addr
+
+  # @method_missing: delegated to ActionDispatch::Integration::Session
+  sig { returns(T.nilable(String)) }
+  attr_accessor :accept
+
+  # @method_missing: delegated to ActionDispatch::Integration::Session
+  sig { returns(Rack::Test::CookieJar) }
+  def cookies; end
+
+  # @method_missing: delegated to ActionDispatch::Integration::Session
+  sig { returns(T.nilable(ActionController::Base)) }
+  attr_reader :controller
 
   # @method_missing: delegated to ActionDispatch::Integration::Session
   sig { returns(ActionDispatch::TestRequest) }
@@ -267,6 +325,10 @@ class ActionDispatch::IntegrationTest
   # @method_missing: delegated to ActionDispatch::Integration::Session
   sig { returns(ActionDispatch::TestResponse) }
   attr_reader :response
+
+  # @method_missing: delegated to ActionDispatch::Integration::Session
+  sig { returns(Integer) }
+  attr_accessor :request_count
 end
 
 class ActionDispatch::Request


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

* Gem name: actionpack
* Gem version: 7.0.4
* Gem source: https://github.com/rails/rails/tree/main/actionpack
* Gem API doc: https://api.rubyonrails.org/files/actionpack/README_rdoc.html
* Tapioca version: Tapioca v0.10.3
* Sorbet version: Sorbet typechecker 0.5.10565 git cd9e60b894bd7de78c100ea91ad8dd20f4109ee2 debug_symbols=true clean=1

Found myself writing a test that needed to use `remote_addr`, so I decided to bite the bullet and add all the `ActionDispatch::Integration::Session` methods that are accessible from `ActionDispatch::IntegrationTest`.

The delegation chain is as follows:
- `ActionDispatch::IntegrationTest` includes the `ActionDispatch::IntegrationTest::Behavior` module [here](https://github.com/rails/rails/blob/v7.0.4/actionpack/lib/action_dispatch/testing/integration.rb#L681)
- `ActionDispatch::IntegrationTest::Behavior` includes the `ActionDispatch::Integration::Runner` module [here](https://github.com/rails/rails/blob/v7.0.4/actionpack/lib/action_dispatch/testing/integration.rb#L644)
- `ActionDispatch::Integration::Runner` delegates missing methods to `ActionDispatch::Integration::Session` [here](https://github.com/rails/rails/blob/v7.0.4/actionpack/lib/action_dispatch/testing/integration.rb#L424-L434) (if the missing method does exist on `ActionDispatch::Integration::Session`)
- the signatures I added are for the `ActionDispatch::Integration::Session` methods defined [here](https://github.com/rails/rails/blob/v7.0.4/actionpack/lib/action_dispatch/testing/integration.rb#L90-L121) (the signatures for `request` and `response` were already present)
- the `#status`, `#status_message`, `#headers`, `#body` and `#redirect?` methods are further delegated to `ActionDispatch::TestResponse` [here](https://github.com/rails/rails/blob/v7.0.4/actionpack/lib/action_dispatch/testing/integration.rb#L90) (with `allow_nil: true`, so the return type for all of these is `T.nilable(something)`
- the `#path` method is further delegated to `ActionDispatch::Request` [here](https://github.com/rails/rails/blob/v7.0.4/actionpack/lib/action_dispatch/testing/integration.rb#L91) (with `allow_nil: true`, so the return type is `T.nilable(String)`)

I've also tested each of the methods in an actual test to ensure the types are correct.
