### PR TITLE
Add RBI for Kredis

### DIFF
--- a/index.json
+++ b/index.json
@@ -60,6 +60,16 @@
   },
   "graphql": {
   },
+  "kredis": {
+    "dependencies": [
+      "activemodel",
+      "kredis"
+    ],
+    "requires": [
+      "active_model",
+      "kredis"
+    ]
+  },
   "lhm": {
   },
   "lhm-shopify": {

--- a/rbi/annotations/kredis.rbi
+++ b/rbi/annotations/kredis.rbi
@@ -1,0 +1,133 @@
+# typed: strict
+
+module Kredis::Types
+  sig { params(key: T.untyped, default: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Scalar) }
+  def boolean(key, default: nil, config: nil, after_change: nil, expires_in: nil); end
+
+  sig { params(key: T.untyped, expires_in: T.untyped, config: T.untyped, after_change: T.untyped).returns(Kredis::Types::Counter) }
+  def counter(key, expires_in: nil, config: nil, after_change: nil); end
+
+  sig { params(key: T.untyped, values: T.untyped, expires_in: T.untyped, config: T.untyped, after_change: T.untyped).returns(Kredis::Types::Cycle) }
+  def cycle(key, values:, expires_in: nil, config: nil, after_change: nil); end
+
+  sig { params(key: T.untyped, default: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Scalar) }
+  def datetime(key, default: nil, config: nil, after_change: nil, expires_in: nil); end
+
+  sig { params(key: T.untyped, default: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Scalar) }
+  def decimal(key, default: nil, config: nil, after_change: nil, expires_in: nil); end
+
+  sig { params(key: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Flag) }
+  def flag(key, config: nil, after_change: nil, expires_in: nil); end
+
+  sig { params(key: T.untyped, default: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Scalar) }
+  def float(key, default: nil, config: nil, after_change: nil, expires_in: nil); end
+
+  sig { params(key: T.untyped, typed: T.untyped, config: T.untyped, after_change: T.untyped).returns(Kredis::Types::Hash) }
+  def hash(key, typed: nil, config: nil, after_change: nil); end
+
+  sig { params(key: T.untyped, default: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Scalar) }
+  def integer(key, default: nil, config: nil, after_change: nil, expires_in: nil); end
+
+  sig { params(key: T.untyped, default: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Scalar) }
+  def json(key, default: nil, config: nil, after_change: nil, expires_in: nil); end
+
+  sig { params(key: T.untyped, typed: T.untyped, config: T.untyped, after_change: T.untyped).returns(Kredis::Types::List) }
+  def list(key, typed: nil, config: nil, after_change: nil); end
+
+  sig { params(key: T.untyped, config: T.untyped, after_change: T.untyped).returns(Kredis::Types::Proxy) }
+  def proxy(key, config: nil, after_change: nil); end
+
+  sig { params(key: T.untyped, typed: T.untyped, default: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Scalar) }
+  def scalar(key, typed: nil, default: nil, config: nil, after_change: nil, expires_in: nil); end
+
+  sig { params(key: T.untyped, typed: T.untyped, config: T.untyped, after_change: T.untyped,).returns(Kredis::Types::Set) }
+  def set(key, typed: nil, config: nil, after_change: nil); end
+
+  sig { params(key: T.untyped, config: T.untyped, after_change: T.untyped).returns(Kredis::Types::Slots) }
+  def slot(key, config: nil, after_change: nil); end
+
+  sig { params(key: T.untyped, available: T.untyped, config: T.untyped, after_change: T.untyped).returns(Kredis::Types::Slots) }
+  def slots(key, available:, config: nil, after_change: nil); end
+
+  sig { params(key: T.untyped, default: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Scalar) }
+  def string(key, default: nil, config: nil, after_change: nil, expires_in: nil); end
+
+  sig { params(key: T.untyped, typed: T.untyped, limit: T.untyped, config: T.untyped, after_change: T.untyped).returns(Kredis::Types::UniqueList) }
+  def unique_list(key, typed: nil, limit: nil, config: nil, after_change: nil); end
+end
+
+class Kredis::Types::Counter
+  sig { params(by: Integer).returns(Integer) }
+  def increment(by: 1); end
+
+  sig { params(by: Integer).returns(Integer) }
+  def decrement(by: 1); end
+
+  sig { returns(Integer) }
+  def value; end
+end
+
+class Kredis::Types::Flag
+  sig { returns(T::Boolean) }
+  def marked?; end
+end
+
+class Kredis::Types::Hash
+  sig { returns(ActiveSupport::HashWithIndifferentAccess) }
+  def entries; end
+
+  sig { returns(T::Array[String]) }
+  def keys; end
+
+  sig { returns(T::Array[T.untyped]) }
+  def values; end
+
+  sig { params(keys: T.untyped).returns(T::Array[T.untyped]) }
+  def values_at(*keys); end
+end
+
+class Kredis::Types::List
+  sig { returns(T::Array[T.untyped]) }
+  def elements; end
+end
+
+class Kredis::Types::Proxy
+  # @method_missing: subclasses delegate (via `proxying` class method) to Proxy, https://github.com/rails/kredis/blob/v1.3.0/lib/kredis/types/proxy.rb#L23
+  sig { params(_arg0: T.untyped, _arg1: T.untyped, _arg2: T.nilable(T.proc.void)).returns(T::Boolean) }
+  def exists?(*_arg0, **_arg1, &_arg2); end
+end
+
+class Kredis::Types::Scalar
+  sig { returns(T::Boolean) }
+  def assigned?; end
+end
+
+class Kredis::Types::Set
+  sig { returns(T::Array[T.untyped]) }
+  def members; end
+
+  sig { params(member: T.untyped).returns(T::Boolean) }
+  def include?(member); end
+
+  sig { returns(Integer) }
+  def size; end
+end
+
+class Kredis::Types::Slots
+  sig { params(block: T.nilable(T.proc.returns(T::Boolean))).returns(T::Boolean) }
+  def reserve(&block); end
+
+  sig { returns(T::Boolean) }
+  def release; end
+
+  sig { returns(T::Boolean) }
+  def available?; end
+
+  sig { returns(Integer) }
+  def taken; end
+end
+
+class Kredis::Types::UniqueList
+  sig { returns(T::Array[T.untyped]) }
+  def elements; end
+end


### PR DESCRIPTION
### Type of Change

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

`Kredis::Attributes` is also [included in `ActiveModel::Model`](https://github.com/rails/kredis/blob/v1.3.0/lib/kredis/railtie.rb#L25-L27), but I had trouble getting the requires right (it seemed like a game of whack-a-mole adding requires for model, api, validations, etc in index.json), any pointers welcome on how to do this in a more sane way.

### Changes

* Gem name: Kredis
* Gem version: 1.3.0
* Gem source: https://github.com/rails/kredis/blob/v1.3.0/lib/kredis/types.rb
* Tapioca version: 0.10.3
* Sorbet version: 0.5.10565 git cd9e60b894bd7de78c100ea91ad8dd20f4109ee2 debug_symbols=true clean=1
