### PR TITLE
`ActiveSupport::TimeWithZone` inherits `Time`

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -46,3 +46,6 @@ class Object
   sig { returns(T::Boolean) }
   def present?; end
 end
+
+class ActiveSupport::TimeWithZone < Time
+end

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -47,5 +47,7 @@ class Object
   def present?; end
 end
 
-class ActiveSupport::TimeWithZone < Time
+class ActiveSupport::TimeWithZone
+   # @shim: Methods are delegated to `Time` using `method_missing`
+  include Time
 end


### PR DESCRIPTION
According to documentation, `ActiveSupport::TimeWithZone` implements all `Time` methods. Is this the best way to do this?

https://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html