### PR TITLE
Add signatures for ActiveSupport extensions to Array

### DIFF
--- a/index.json
+++ b/index.json
@@ -27,6 +27,7 @@
   "activesupport": {
     "requires": [
       "active_support",
+      "active_support/core_ext/array",
       "active_support/test_case"
     ]
   },

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -46,3 +46,83 @@ class Object
   sig { returns(T::Boolean) }
   def present?; end
 end
+
+class Hash
+  sig { returns(T::Boolean) }
+  def extractable_options?; end
+end
+
+class Array
+  sig { params(position: Integer).returns(T.self_type) }
+  def from(position); end
+
+  sig { params(position: Integer).returns(T.self_type) }
+  def to(position); end
+
+  sig { params(elements: T.untyped).returns(T::Array[T.untyped]) }
+  def including(*elements); end
+
+  sig { params(elements: T.untyped).returns(T.self_type) }
+  def excluding(*elements); end
+
+  sig { params(elements: T.untyped).returns(T.self_type) }
+  def without(*elements); end
+
+  sig { returns(T.nilable(Elem)) }
+  def second; end
+
+  sig { returns(T.nilable(Elem)) }
+  def third; end
+
+  sig { returns(T.nilable(Elem)) }
+  def fourth; end
+
+  sig { returns(T.nilable(Elem)) }
+  def fifth; end
+
+  sig { returns(T.nilable(Elem)) }
+  def forty_two; end
+
+  sig { returns(T.nilable(Elem)) }
+  def third_to_last; end
+
+  sig { returns(T.nilable(Elem)) }
+  def second_to_last; end
+
+  sig { params(options: T::Hash[T.untyped, T.untyped]).returns(String) }
+  def to_sentence(options = {}); end
+
+  sig { params(format: Symbol).returns(String) }
+  def to_fs(format = :default); end
+
+  sig { params(format: Symbol).returns(String) }
+  def to_formatted_s(format = :default); end
+
+  sig { returns(String) }
+  def to_xml; end
+
+  sig { returns(T::Hash[T.untyped, T.untyped]) }
+  def extract_options!; end
+
+  sig do
+    params(number: Integer, fill_with: T.untyped, block: T.nilable(T.proc.void)).returns(T::Array[T::Array[Elem]])
+  end
+  def in_groups(number, fill_with = nil, &block); end
+
+  sig do
+    params(number: Integer, fill_with: T.untyped, block: T.nilable(T.proc.void)).returns(T::Array[T::Array[Elem]])
+  end
+  def in_groups_of(number, fill_with = nil, &block); end
+
+  sig { params(value: T.untyped, block: T.nilable(T.proc.void)).returns(T::Array[T::Array[Elem]]) }
+  def split(value = nil, &block); end
+
+  sig { params(object: T.untyped).returns(T::Array[T.untyped]) }
+  def self.wrap(object); end
+
+  sig { returns(T.untyped) }
+  def extract!; end
+
+  sig { returns(ActiveSupport::ArrayInquirer) }
+  def inquiry; end
+end

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -105,16 +105,31 @@ class Array
   def extract_options!; end
 
   sig do
-    params(number: Integer, fill_with: T.untyped, block: T.nilable(T.proc.void)).returns(T::Array[T::Array[Elem]])
+    type_parameters(:FillType)
+      .params(
+        number: Integer,
+        fill_with: T.type_parameter(:FillType),
+        block: T.nilable(T.proc.params(group: T::Array[T.any(Elem, T.type_parameter(:FillType))]).void),
+      )
+      .returns(T::Array[T.any(Elem, T.type_parameter(:FillType))])
   end
-  def in_groups(number, fill_with = nil, &block); end
+  def in_groups(number, fill_with = T.unsafe(nil), &block); end
 
   sig do
-    params(number: Integer, fill_with: T.untyped, block: T.nilable(T.proc.void)).returns(T::Array[T::Array[Elem]])
+    type_parameters(:FillType)
+      .params(
+        number: Integer,
+        fill_with: T.type_parameter(:FillType),
+        block: T.nilable(T.proc.params(group: T::Array[T.any(Elem, T.type_parameter(:FillType))]).void),
+      )
+      .returns(T::Array[T.any(Elem, T.type_parameter(:FillType))])
   end
-  def in_groups_of(number, fill_with = nil, &block); end
+  def in_groups_of(number, fill_with = T.unsafe(nil), &block); end
 
-  sig { params(value: T.untyped, block: T.nilable(T.proc.void)).returns(T::Array[T::Array[Elem]]) }
+  sig do
+    params(value: T.untyped, block: T.nilable(T.proc.params(element: Elem).returns(T.untyped)))
+      .returns(T::Array[T::Array[Elem]])
+  end
   def split(value = nil, &block); end
 
   sig { params(object: T.untyped).returns(T::Array[T.untyped]) }


### PR DESCRIPTION
### Type of Change

- [x] Modify RBI for an existing gem

### Changes

Add signatures to all extensions for `Array` made by `ActiveSupport`. Closes https://github.com/Shopify/rbi-central/issues/139

* Gem name: activesupport
* Gem version: 7.1.0.alpha
* Gem source: https://github.com/rails/rails/tree/main/activesupport/lib/active_support/core_ext/array
