### PR TITLE
Fix return type of `Array#in_groups` and `Array#in_groups_of`

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -122,7 +122,7 @@ class Array
         fill_with: T.type_parameter(:FillType),
         block: T.nilable(T.proc.params(group: T::Array[T.any(Elem, T.type_parameter(:FillType))]).void),
       )
-      .returns(T::Array[T.any(Elem, T.type_parameter(:FillType))])
+      .returns(T::Array[T::Array[T.any(Elem, T.type_parameter(:FillType))]])
   end
   def in_groups_of(number, fill_with = T.unsafe(nil), &block); end
 

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -111,7 +111,7 @@ class Array
         fill_with: T.type_parameter(:FillType),
         block: T.nilable(T.proc.params(group: T::Array[T.any(Elem, T.type_parameter(:FillType))]).void),
       )
-      .returns(T::Array[T.any(Elem, T.type_parameter(:FillType))])
+      .returns(T::Array[T::Array[T.any(Elem, T.type_parameter(:FillType))]])
   end
   def in_groups(number, fill_with = T.unsafe(nil), &block); end
 


### PR DESCRIPTION
### Type of Change

https://github.com/Shopify/rbi-central/pull/144/files#r1070955166

```rb
irb(main):001:0> [1, 2, 3].in_groups(3)
=> [[1], [2], [3]]

irb(main):001:0> [1, 2, 3].in_groups_of(3)
=> [[1, 2, 3]]
```

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: <!-- Add the name of the gem you have a problem with here --> activesupport
* Gem version: <!-- Add the version of the gem you have a problem with here (if applicable) --> 
* Gem source: <!-- Link relevant source code from the gem for the problem you have --> https://github.com/rails/rails/blob/8015c2c2cf5c8718449677570f372ceb01318a32/activesupport/lib/active_support/core_ext/array/grouping.rb#L62
* Gem API doc: <!-- Link relevant API doc from the gem for the problem you have --> 
* Tapioca version: <!-- Add the version of Tapioca you use -->
* Sorbet version: <!-- Add the version of Sorbet you use -->
