### PR TITLE
Add types to GlobalID::Identification

### DIFF
--- a/index.json
+++ b/index.json
@@ -56,7 +56,8 @@
       "activerecord"
     ],
     "requires": [
-      "active_record"
+      "active_record",
+      "global_id/identification"
     ]
   },
   "graphql": {

--- a/rbi/annotations/globalid.rbi
+++ b/rbi/annotations/globalid.rbi
@@ -4,3 +4,23 @@ class ActiveRecord::Base
   # @shim: this is included at runtime https://github.com/rails/globalid/blob/v1.0.0/lib/global_id/railtie.rb#L38
   include GlobalID::Identification
 end
+
+module GlobalID::Identification
+  sig { params(options: T::Hash[T.untyped, T.untyped]).returns(GlobalID) }
+  def to_gid(options = {}); end
+
+  sig { params(options: T::Hash[T.untyped, T.untyped]).returns(String) }
+  def to_gid_param(options = {}); end
+
+  sig { params(options: T::Hash[T.untyped, T.untyped]).returns(GlobalID) }
+  def to_global_id(options = {}); end
+
+  sig { params(options: T::Hash[T.untyped, T.untyped]).returns(SignedGlobalID) }
+  def to_sgid(options = {}); end
+
+  sig { params(options: T::Hash[T.untyped, T.untyped]).returns(String) }
+  def to_sgid_param(options = {}); end
+
+  sig { params(options: T::Hash[T.untyped, T.untyped]).returns(SignedGlobalID) }
+  def to_signed_global_id(options = {}); end
+end


### PR DESCRIPTION
### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

I keep using `to_gid` as if it returns a string and it doesn't 😅 https://github.com/rails/globalid/blob/main/lib/global_id/identification.rb
