### PR TITLE
Add ActiveRecord callback signatures

### DIFF
--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -11,3 +11,176 @@ class ActiveRecord::Migration
   # @shim: Methods on migration are delegated to `DatabaseaStatements` using `method_missing`
   include ActiveRecord::ConnectionAdapters::DatabaseStatements
 end
+
+class ActiveRecord::Base
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_initialize(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_find(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_touch(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.before_validation(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_validation(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.before_save(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.around_save(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_save(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.before_create(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.around_create(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_create(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.before_update(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.around_update(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_update(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.before_destroy(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.around_destroy(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_destroy(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_commit(*args, **options, &block); end
+
+  sig do
+    params(
+      args: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(record: T.attached_class).void)
+    ).void
+  end
+  def self.after_rollback(*args, **options, &block); end
+end


### PR DESCRIPTION
These callback methods execute their blocks in the context of the model instance. This means that without these signatures, users will have to keep using `T.bind` inside the block to get the correct type for the binding of the block.

Ref: https://github.com/sorbet/sorbet/issues/6698

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: activerecord
* Gem version: *
