### PR TITLE
Add signatures for Action Controller content_security_policy and permissions_policy

### DIFF
--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -4,6 +4,17 @@ class ActionController::API
   MODULES = T.let(T.unsafe(nil), T::Array[T.untyped])
 end
 
+module ActionController::ContentSecurityPolicy::ClassMethods
+  sig do
+    params(
+      enabled: T.untyped,
+      options: T.untyped,
+      block: T.nilable(T.proc.params(policy: ActionDispatch::ContentSecurityPolicy).void)
+    ).void
+  end
+  def content_security_policy(enabled = true, **options, &block); end
+end
+
 module ActionController::Flash::ClassMethods
   sig { params(types: Symbol).void }
   def add_flash_types(*types); end
@@ -202,6 +213,13 @@ class ActionController::Parameters
 
   sig { params(obj: T::Boolean).void }
   def self.permit_all_parameters=(obj); end
+end
+
+module ActionController::PermissionsPolicy::ClassMethods
+  sig do
+    params(options: T.untyped, block: T.nilable(T.proc.params(policy: ActionDispatch::PermissionsPolicy).void)).void
+  end
+  def permissions_policy(**options, &block); end
 end
 
 module ActionController::RequestForgeryProtection

--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -4,12 +4,18 @@ class ActionController::API
   MODULES = T.let(T.unsafe(nil), T::Array[T.untyped])
 end
 
+# @version >= 5.2.0
 module ActionController::ContentSecurityPolicy::ClassMethods
+  # @shim: required to declare T.attached_class
+  extend T::Generic
+
+  has_attached_class!(:out)
+
   sig do
     params(
       enabled: T.untyped,
       options: T.untyped,
-      block: T.nilable(T.proc.params(policy: ActionDispatch::ContentSecurityPolicy).void)
+      block: T.nilable(T.proc.bind(T.attached_class).params(policy: ActionDispatch::ContentSecurityPolicy).void)
     ).void
   end
   def content_security_policy(enabled = true, **options, &block); end
@@ -215,9 +221,18 @@ class ActionController::Parameters
   def self.permit_all_parameters=(obj); end
 end
 
+# @version >= 6.1.0
 module ActionController::PermissionsPolicy::ClassMethods
+  # @shim: required to declare T.attached_class
+  extend T::Generic
+
+  has_attached_class!(:out)
+
   sig do
-    params(options: T.untyped, block: T.nilable(T.proc.params(policy: ActionDispatch::PermissionsPolicy).void)).void
+    params(
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.attached_class).params(policy: ActionDispatch::PermissionsPolicy).void)
+    ).void
   end
   def permissions_policy(**options, &block); end
 end


### PR DESCRIPTION
The block for content_security_policy [should have `bind(T.attached_class)` I believe](https://github.com/rails/rails/blob/93b1d3998cf5ce1e0cc91ebb0e6e65993bcec54a/actionpack/lib/action_controller/metal/content_security_policy.rb#L43) but that's not possible with modules at the moment.

### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->