### PR TITLE
Add a few methods and classes to the Stripe RBI

### DIFF
--- a/rbi/annotations/stripe.rbi
+++ b/rbi/annotations/stripe.rbi
@@ -1,7 +1,10 @@
 # typed: strict
 
 class Stripe::APIResource < Stripe::StripeObject
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::APIResource) }
+  def self.retrieve(id, opts = nil); end
 
   sig { returns(Stripe::APIResource) }
   def refresh; end
@@ -18,33 +21,40 @@ class Stripe::APIResource < Stripe::StripeObject
   # @method_missing: from StripeObject
   sig { params(val: T::Hash[T.any(String, Symbol), T.untyped]).void }
   def metadata=(val); end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::APIResource) }
-  def self.retrieve(id, opts = nil); end
 end
 
 class Stripe::ApplicationFee < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::ApplicationFee) }
+  def self.retrieve(id, opts = nil); end
 
   # @method_missing: from StripeObject
   sig { returns(String) }
   def id; end
+
+  # @method_missing: from StripeObject
+  sig { returns(Stripe::ListObject) }
+  def refunds; end
 end
 
 class Stripe::BalanceTransaction < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::BalanceTransaction) }
+  def self.retrieve(id, opts = {}); end
 
   # @method_missing: from StripeObject
   sig { returns(String) }
   def type; end
 
   # @method_missing: from StripeObject
-  sig { returns(String)}
+  sig { returns(String) }
   def currency; end
 
   # if resource is expanded, the actual object is returned
   # @method_missing: from StripeObject
-  sig { returns(T.any(String, Stripe::Charge, Stripe::Refund))}
+  sig { returns(T.any(String, Stripe::Charge, Stripe::Refund)) }
   def source; end
 
   # @method_missing: from StripeObject
@@ -62,13 +72,10 @@ class Stripe::BalanceTransaction < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { returns(Integer) }
   def created; end
-
-  sig { params(id: String, opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::BalanceTransaction) }
-  def self.retrieve(id, opts = {}); end
 end
 
 class Stripe::BankAccount < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   # @method_missing: from StripeObject
   sig { returns(String) }
@@ -88,7 +95,10 @@ class Stripe::BankAccount < Stripe::APIResource
 end
 
 class Stripe::Card < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::Card) }
+  def self.retrieve(id, opts = {}); end
 
   # @method_missing: from StripeObject
   sig { returns(String) }
@@ -125,13 +135,13 @@ class Stripe::Card < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { params(other: String).returns(String) }
   def last4=(other); end
-
-  sig { params(id: String, opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::Card) }
-  def self.retrieve(id, opts = {}); end
 end
 
 class Stripe::Charge < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::Charge) }
+  def self.retrieve(id, opts = {}); end
 
   # @method_missing: from StripeObject
   sig { returns(Stripe::ListObject) }
@@ -142,19 +152,16 @@ class Stripe::Charge < Stripe::APIResource
   def amount_captured; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.nilable(T.any(Stripe::Source, Stripe::Card)))}
+  sig { returns(T.nilable(T.any(Stripe::Source, Stripe::Card))) }
   def source; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.nilable(String))}
+  sig { returns(T.nilable(String)) }
   def failure_message; end
 
   # @method_missing: from StripeObject
   sig { returns(T.any(Stripe::Dispute, String)) }
   def dispute; end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::Charge) }
-  def self.retrieve(id, opts = {}); end
 
   # @method_missing: from StripeObject
   sig { returns(T::Boolean) }
@@ -205,12 +212,12 @@ class Stripe::Charge < Stripe::APIResource
   def payment_intent; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.nilable(T.any(String, Stripe::Customer)))}
+  sig { returns(T.nilable(T.any(String, Stripe::Customer))) }
   def customer; end
 end
 
 class Stripe::Coupon < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Coupon) }
   def self.retrieve(id, opts = nil); end
@@ -221,7 +228,10 @@ class Stripe::Coupon < Stripe::APIResource
 end
 
 class Stripe::CreditNote < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::CreditNote) }
+  def self.retrieve(id, opts = nil); end
 
   # @method_missing: from StripeObject
   sig { returns(Integer) }
@@ -270,13 +280,10 @@ class Stripe::CreditNote < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { returns(T.nilable(Stripe::Refund)) }
   def refund; end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::CreditNote) }
-  def self.retrieve(id, opts = nil); end
 end
 
-class Stripe::CreditNoteLineItem
-  Elem = type_member {{fixed: T.untyped}}
+class Stripe::CreditNoteLineItem < Stripe::StripeObject
+  Elem = type_member { { fixed: T.untyped } }
 
   # @method_missing: from StripeObject
   sig { returns(String) }
@@ -291,20 +298,23 @@ class Stripe::CreditNoteLineItem
   def quantity; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.nilable(String))}
+  sig { returns(T.nilable(String)) }
   def invoice_line_item; end
 
   # @method_missing: from StripeObject
-  sig { returns(String)}
+  sig { returns(String) }
   def type; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.nilable(String))}
+  sig { returns(T.nilable(String)) }
   def description; end
 end
 
 class Stripe::Customer < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.any(String, T::Array[String])]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Customer) }
+  def self.retrieve(id, opts = nil); end
 
   # @method_missing: from StripeObject
   sig { returns(String) }
@@ -345,13 +355,10 @@ class Stripe::Customer < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { returns(T.nilable(String)) }
   def email; end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.any(String, T::Array[String])]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Customer) }
-  def self.retrieve(id, opts = nil); end
 end
 
 class Stripe::CustomerBalanceTransaction < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   # @method_missing: from StripeObject
   sig { returns(Integer) }
@@ -386,8 +393,8 @@ class Stripe::CustomerBalanceTransaction < Stripe::APIResource
   def type; end
 end
 
-class Stripe::Discount
-  Elem = type_member {{fixed: T.untyped}}
+class Stripe::Discount < Stripe::StripeObject
+  Elem = type_member { { fixed: T.untyped } }
 
   # @method_missing: from StripeObject
   sig { returns(Stripe::Coupon) }
@@ -395,7 +402,10 @@ class Stripe::Discount
 end
 
 class Stripe::Dispute < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Dispute) }
+  def self.retrieve(id, opts = nil); end
 
   # @method_missing: from StripeObject
   sig { returns(T.nilable(String)) }
@@ -415,7 +425,7 @@ class Stripe::Dispute < Stripe::APIResource
 end
 
 class Stripe::Event < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   # @method_missing: from StripeObject
   sig { returns(String) }
@@ -434,7 +444,10 @@ class Stripe::Event < Stripe::APIResource
 end
 
 class Stripe::Invoice < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Invoice) }
+  def self.retrieve(id, opts = nil); end
 
   # @method_missing: from StripeObject
   sig { returns(T.nilable(Stripe::PaymentIntent)) }
@@ -451,9 +464,6 @@ class Stripe::Invoice < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { returns(String) }
   def customer; end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Invoice) }
-  def self.retrieve(id, opts = nil); end
 
   # @method_missing: from StripeObject
   sig { returns(Stripe::ListObject) }
@@ -472,7 +482,7 @@ class Stripe::Invoice < Stripe::APIResource
   def charge; end
 
   # @method_missing: from StripeObject
-  sig { returns(T::Boolean)}
+  sig { returns(T::Boolean) }
   def paid; end
 
   # @method_missing: from StripeObject
@@ -492,7 +502,7 @@ class Stripe::Invoice < Stripe::APIResource
 end
 
 class Stripe::InvoiceItem < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::InvoiceItem) }
   def self.retrieve(id, opts = nil); end
@@ -502,15 +512,15 @@ class Stripe::InvoiceItem < Stripe::APIResource
   def plan; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.nilable(String))}
+  sig { returns(T.nilable(String)) }
   def description; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.any(Stripe::Customer, String))}
+  sig { returns(T.any(Stripe::Customer, String)) }
   def customer; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.any(Stripe::Invoice, String))}
+  sig { returns(T.any(Stripe::Invoice, String)) }
   def invoice; end
 
   # unsure how to represent a StripeObject with specific keys/mmethods without causing typing errors
@@ -518,8 +528,15 @@ class Stripe::InvoiceItem < Stripe::APIResource
   def period; end
 end
 
+class Stripe::File < Stripe::APIResource
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::File) }
+  def self.retrieve(id, opts = nil); end
+end
+
 class Stripe::ListObject
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   # @method_missing: from StripeObject
   sig { returns(T::Array[T.untyped]) }
@@ -531,7 +548,10 @@ class Stripe::ListObject
 end
 
 class Stripe::PaymentIntent < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.any(String, T::Array[String])]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::PaymentIntent) }
+  def self.retrieve(id, opts = nil); end
 
   # @method_missing: from StripeObject
   sig { returns(String) }
@@ -548,13 +568,13 @@ class Stripe::PaymentIntent < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { returns(Stripe::ListObject) }
   def line_items; end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.any(String, T::Array[String])]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::PaymentIntent) }
-  def self.retrieve(id, opts = nil); end
 end
 
 class Stripe::PaymentMethod < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::PaymentMethod) }
+  def self.retrieve(id, opts = nil); end
 
   # @method_missing: from StripeObject
   sig { returns(Stripe::Card) }
@@ -563,13 +583,13 @@ class Stripe::PaymentMethod < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { returns(String) }
   def type; end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::PaymentMethod) }
-  def self.retrieve(id, opts = nil); end
 end
 
 class Stripe::Payout < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.any(String, T::Array[String])]), opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::Payout) }
+  def self.retrieve(id, opts = {}); end
 
   # @method_missing: from StripeObject
   sig { returns(Integer) }
@@ -582,28 +602,25 @@ class Stripe::Payout < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { returns(Integer) }
   def amount; end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.any(String, T::Array[String])]), opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::Payout) }
-  def self.retrieve(id, opts = {}); end
 end
 
 class Stripe::Plan < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Plan) }
+  def self.retrieve(id, opts = {}); end
 
   # unsure how to represent a StripeObject with specific keys/mmethods without causing typing errors
   # @method_missing: from StripeObject
   def period; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.any(String, Stripe::Product))}
+  sig { returns(T.any(String, Stripe::Product)) }
   def product; end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Plan) }
-  def self.retrieve(id, opts = {}); end
 end
 
 class Stripe::Product < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Product) }
   def self.retrieve(id, opts = {}); end
@@ -622,7 +639,7 @@ class Stripe::Product < Stripe::APIResource
 end
 
 class Stripe::Refund < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   sig { params(id: T.any(String, T::Hash[Symbol, T.any(String, T::Array[String])]), opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::Refund) }
   def self.retrieve(id, opts = {}); end
@@ -636,20 +653,20 @@ class Stripe::Refund < Stripe::APIResource
   def amount; end
 
   # @method_missing: from StripeObject
-  sig { returns(T.nilable(T.any(String, Stripe::CreditNote)))}
+  sig { returns(T.nilable(T.any(String, Stripe::CreditNote))) }
   def credit_note; end
 
   # @method_missing: from StripeObject
-  sig { returns(String)}
+  sig { returns(String) }
   def currency; end
 
   # @method_missing: from StripeObject
-  sig { returns(Integer)}
+  sig { returns(Integer) }
   def created; end
 end
 
 class Stripe::Source < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Source) }
   def self.retrieve(id, opts = nil); end
@@ -664,7 +681,7 @@ class Stripe::StripeError
 end
 
 class Stripe::StripeObject
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   # @method_missing: from StripeObject
   sig { returns(T.any(Stripe::Subscription, Stripe::Customer, Stripe::Invoice)) }
@@ -675,7 +692,10 @@ class Stripe::StripeObject
 end
 
 class Stripe::Subscription < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Subscription) }
+  def self.retrieve(id, opts = nil); end
 
   # @method_missing: from StripeObject
   sig { params(val: T::Array[T::Hash[Symbol, T.untyped]]).void }
@@ -696,13 +716,10 @@ class Stripe::Subscription < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { returns(T.nilable(T.any(T.nilable(Stripe::Invoice), T.nilable(String)))) }
   def latest_invoice; end
-
-  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Subscription) }
-  def self.retrieve(id, opts = nil); end
 end
 
 class Stripe::TaxRate < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   # @method_missing: from StripeObject
   sig { returns(T.nilable(String)) }
@@ -718,7 +735,7 @@ class Stripe::TaxRate < Stripe::APIResource
 end
 
 class Stripe::Token < Stripe::APIResource
-  Elem = type_member {{fixed: T.untyped}}
+  Elem = type_member { { fixed: T.untyped } }
 
   sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Token) }
   def self.retrieve(id, opts = nil); end
@@ -730,4 +747,15 @@ class Stripe::Token < Stripe::APIResource
   # @method_missing: from StripeObject
   sig { returns(Stripe::BankAccount) }
   def bank_account; end
+end
+
+class Stripe::Transfer < Stripe::APIResource
+  Elem = type_member { { fixed: T.untyped } }
+
+  sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::Transfer) }
+  def self.retrieve(id, opts = nil); end
+
+  # @method_missing: from StripeObject
+  sig { returns(Stripe::ListObject) }
+  def reversals; end
 end


### PR DESCRIPTION
Those methods are based in our codebase usage, and are in no way the entire list of existing objects and methods in the Stripe API.

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: stripe
* Gem version: 8.3.0
* Gem source:https://github.com/stripe/stripe-ruby/tree/v8.3.0
* Gem API doc: https://stripe.com/docs/api
* Tapioca version: any
* Sorbet version: any
