### PR TITLE
Update actionpack annotations to match the Rails behavior and improve usability

### DIFF
--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -270,7 +270,7 @@ class ActionDispatch::IntegrationTest
   def status_message; end
 
   # @method_missing: delegated to ActionDispatch::TestResponse
-  sig { returns(T.nilable(ActionDispatch::Response::Header)) }
+  sig { returns(ActionDispatch::Response::Header) }
   def headers; end
 
   # @method_missing: delegated to ActionDispatch::TestResponse

--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -108,22 +108,14 @@ class ActionController::Parameters
   sig { params(block: T.untyped).returns(T.untyped) }
   def reject(&block); end
 
-  sig { params(key: T.any(String, Symbol)).returns(T.nilable(T.any(String, Numeric, ActionController::Parameters))) }
+  sig { params(key: T.any(String, Symbol)).returns(T.untyped) }
   def [](key); end
 
-  sig do
-    params(
-      key: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
-    ).returns(T.any(String, Numeric, T::Array[T.untyped], ActionController::Parameters))
-  end
+  sig { params(key: T.any(String, Symbol, T::Array[T.any(String, Symbol)])).returns(T.untyped) }
   def require(key); end
 
   # required is an alias of require
-  sig do
-    params(
-      key: T.any(String, Symbol, T::Array[T.any(String, Symbol)])
-    ).returns(T.any(String, Numeric, T::Array[T.untyped], ActionController::Parameters))
-  end
+  sig { params(key: T.any(String, Symbol, T::Array[T.any(String, Symbol)])).returns(T.untyped) }
   def required(key); end
 
   sig { params(other_hash: T.untyped).returns(ActionController::Parameters) }

--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -224,11 +224,11 @@ end
 
 module ActionDispatch::Http::Parameters
   sig { returns(ActionController::Parameters) }
-  def parameters(); end
+  def parameters; end
 
   # params is an alias of parameters
   sig { returns(ActionController::Parameters) }
-  def params(); end
+  def params; end
 end
 
 module ActionDispatch::Integration::Runner
@@ -253,7 +253,6 @@ class ActionDispatch::IntegrationTest
   # `TestResponse` / `Request` (via `delegate`).
   #
   # Cf. https://github.com/Shopify/rbi-central/pull/138 for more context.
-
   # @method_missing: delegated to ActionDispatch::TestProcess
   sig { returns(ActionDispatch::Flash::FlashHash) }
   def flash; end


### PR DESCRIPTION
Two change:

The first, is changing the signture of `headers` method to always return the object, never nil.

The main change is, returning T.untyped in the `ActionController::Parameters` methods.

Trying to return the correct type for the parameters methods decrease the usability of Rails.

Code like:

```
params.require(:user).permit(:name)
```

will not be able to be typed without doing something like:

```
T.cast(params.require(:user), ActionController::Parameters).permit(:name)
```

and this is now how we should be writing Rails code.

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: actionpack
* Gem version: 7.0
* Gem source: https://github.com/rails/rails
* Gem API doc: https://api.rubyonrails.org/
* Tapioca version: any
* Sorbet version: any