### PR TITLE
`link_to` accept name as `nil`

### DIFF
--- a/rbi/annotations/actionview.rbi
+++ b/rbi/annotations/actionview.rbi
@@ -49,7 +49,7 @@ module ActionView::Helpers::UrlHelper
 
   sig do
     params(
-      name: String,
+      name: T.nilable(String),
       options: T.untyped,
       html_options: T.untyped,
       block: T.untyped


### PR DESCRIPTION
```
helper.link_to(nil, "https://foo")
=> "<a href=\"https://foo\">https://foo</a>"
```

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: actionview
* Gem version: all
