### PR TITLE
Fix signature for ActiveModel::Errors#details

### DIFF
--- a/rbi/annotations/activemodel.rbi
+++ b/rbi/annotations/activemodel.rbi
@@ -21,7 +21,7 @@ class ActiveModel::Errors
   sig { params(attribute: T.any(Symbol, String), type: T.untyped, options: T.untyped).returns(T.nilable(T::Array[String])) }
   def delete(attribute, type = nil, **options); end
 
-  sig { returns(T::Hash[Symbol, T::Array[T::Hash[Symbol, Symbol]]]) }
+  sig { returns(T::Hash[Symbol, T::Array[T::Hash[Symbol, T.untyped]]]) }
   def details; end
 
   sig { returns(T::Array[Elem]) }


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

Closes https://github.com/Shopify/rbi-central/issues/157

* Gem name: activemodel
* Gem version: 7.1.0.alpha
* Gem source: https://github.com/rails/rails/blob/210932662bf04ba20aa0f579832212f921e62576/activemodel/lib/active_model/errors.rb#L250-L258
* Gem API doc: https://edgeapi.rubyonrails.org/classes/ActiveModel/Errors.html
* Tapioca version: v0.11.1
* Sorbet version: 0.5.10712

cc @bdewater 
