### PR TITLE
TimeWithZone calculations

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -41,7 +41,9 @@ end
 
 class ActiveSupport::TimeWithZone
   include ::Comparable
+  # @shim: Methods on ActiveSupport::TimeWithZone are delegated to `Time` using `method_missing
   include ::DateAndTime::Zones
+  # @shim: Methods on ActiveSupport::TimeWithZone are delegated to `Time` using `method_missing
   include ::DateAndTime::Calculations
   include ::DateAndTime::Compatibility
 end


### PR DESCRIPTION
Include calculations that time has since `ActiveSupport::TimeWithZone` has them too https://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html