### PR TITLE
Add block param to Array#extract!

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -142,8 +142,11 @@ class Array
   sig { params(object: T.untyped).returns(T::Array[T.untyped]) }
   def self.wrap(object); end
 
-  sig { returns(T.untyped) }
-  def extract!; end
+  sig do
+    params(block: T.nilable(T.proc.params(element: Elem).returns(T.untyped)))
+      .returns(T::Array[T::Array[Elem]])
+  end
+  def extract!(&block); end
 
   sig { returns(ActiveSupport::ArrayInquirer) }
   def inquiry; end

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -144,7 +144,7 @@ class Array
 
   sig do
     params(block: T.nilable(T.proc.params(element: Elem).returns(T.untyped)))
-      .returns(T::Array[T::Array[Elem]])
+      .returns(T.any(T::Array[Elem], T::Enumerator[Elem]))
   end
   def extract!(&block); end
 


### PR DESCRIPTION
Fix the signature by adding the missing parameter and improve it to include the block, its type, and the method return type

### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

Fixes #164 