### PR TITLE
Add duration methods to Numeric

### DIFF
--- a/index.json
+++ b/index.json
@@ -34,6 +34,7 @@
       "active_support",
       "active_support/core_ext/array",
       "active_support/core_ext/numeric/time",
+      "active_support/core_ext/integer/time",
       "active_support/test_case"
     ]
   },

--- a/index.json
+++ b/index.json
@@ -33,6 +33,7 @@
     "requires": [
       "active_support",
       "active_support/core_ext/array",
+      "active_support/core_ext/numeric/time",
       "active_support/test_case"
     ]
   },

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -59,7 +59,7 @@ class Hash
   def extractable_options?; end
 end
 
-class Integer
+class Numeric
   sig { returns(ActiveSupport::Duration) }
   def seconds; end
   sig { returns(ActiveSupport::Duration) }

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -88,6 +88,12 @@ class Numeric
   def years; end
   sig { returns(ActiveSupport::Duration) }
   def year; end
+  sig { returns(ActiveSupport::Duration) }
+  def fortnight; end
+  sig { returns(ActiveSupport::Duration) }
+  def fortnights; end
+  sig { returns(Integer) }
+  def in_milliseconds; end
 end
 
 class Array

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -59,6 +59,37 @@ class Hash
   def extractable_options?; end
 end
 
+class Integer
+  sig { returns(ActiveSupport::Duration) }
+  def seconds; end
+  sig { returns(ActiveSupport::Duration) }
+  def second; end
+  sig { returns(ActiveSupport::Duration) }
+  def minutes; end
+  sig { returns(ActiveSupport::Duration) }
+  def minute; end
+  sig { returns(ActiveSupport::Duration) }
+  def hours; end
+  sig { returns(ActiveSupport::Duration) }
+  def hour; end
+  sig { returns(ActiveSupport::Duration) }
+  def days; end
+  sig { returns(ActiveSupport::Duration) }
+  def day; end
+  sig { returns(ActiveSupport::Duration) }
+  def weeks; end
+  sig { returns(ActiveSupport::Duration) }
+  def week; end
+  sig { returns(ActiveSupport::Duration) }
+  def months; end
+  sig { returns(ActiveSupport::Duration) }
+  def month; end
+  sig { returns(ActiveSupport::Duration) }
+  def years; end
+  sig { returns(ActiveSupport::Duration) }
+  def year; end
+end
+
 class Array
   sig { params(position: Integer).returns(T.self_type) }
   def from(position); end

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -60,6 +60,7 @@ class Hash
 end
 
 class Integer
+  sig { returns(ActiveSupport::Duration) }
   def months; end
   sig { returns(ActiveSupport::Duration) }
   def month; end
@@ -67,7 +68,6 @@ class Integer
   def years; end
   sig { returns(ActiveSupport::Duration) }
   def year; end
-  sig { returns(ActiveSupport::Duration) }
 end
 
 class Numeric

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -59,6 +59,17 @@ class Hash
   def extractable_options?; end
 end
 
+class Integer
+  def months; end
+  sig { returns(ActiveSupport::Duration) }
+  def month; end
+  sig { returns(ActiveSupport::Duration) }
+  def years; end
+  sig { returns(ActiveSupport::Duration) }
+  def year; end
+  sig { returns(ActiveSupport::Duration) }
+end
+
 class Numeric
   sig { returns(ActiveSupport::Duration) }
   def seconds; end
@@ -80,14 +91,6 @@ class Numeric
   def weeks; end
   sig { returns(ActiveSupport::Duration) }
   def week; end
-  sig { returns(ActiveSupport::Duration) }
-  def months; end
-  sig { returns(ActiveSupport::Duration) }
-  def month; end
-  sig { returns(ActiveSupport::Duration) }
-  def years; end
-  sig { returns(ActiveSupport::Duration) }
-  def year; end
   sig { returns(ActiveSupport::Duration) }
   def fortnight; end
   sig { returns(ActiveSupport::Duration) }


### PR DESCRIPTION
See: #137

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: activesupport
* Gem version: 
* Gem source:
  https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/numeric/time.rb#L9
  https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/integer/time.rb
* Gem API doc: https://api.rubyonrails.org/classes/Numeric.html#method-i-seconds (similar for other methods).
* Tapioca version: 0.11.6
* Sorbet version: 
