### PR TITLE
Replace `Class` with `T::Class[T.anything]` in lhm-shopify RBI

### DIFF
--- a/rbi/annotations/lhm-shopify.rbi
+++ b/rbi/annotations/lhm-shopify.rbi
@@ -153,7 +153,7 @@ class Lhm::Migrator
 end
 
 module Lhm::Throttler
-  sig { params(type: T.any(Lhm::Command, Symbol, String, Class), options: T::Hash[T.untyped, T.untyped]).void }
+  sig { params(type: T.any(Lhm::Command, Symbol, String, T::Class[T.anything]), options: T::Hash[T.untyped, T.untyped]).void }
   def setup_throttler(type, options = {}); end
 
   sig { returns(Lhm::Throttler) }
@@ -184,7 +184,7 @@ end
 class Lhm::Throttler::Factory
   sig do
     params(
-      type: T.any(Lhm::Command, Symbol, String, Class),
+      type: T.any(Lhm::Command, Symbol, String, T::Class[T.anything]),
       options: T::Hash[T.untyped, T.untyped]
     ).returns(Lhm::Throttler)
   end


### PR DESCRIPTION
Sorbet now considers `Class` to be a generic
(https://github.com/sorbet/sorbet/pull/6781), which means that annotations continuing to use the bare `Class` in type signatures will cause type checking errors on Sorbet versions `[0.5.10820.20230511164542-d94b3e0b2](https://github.com/sorbet/sorbet/releases/tag/0.5.10820.20230511164542-d94b3e0b2)` and newer.

This PR changes two instances of bare `Class` to `T::Class[T.anything]` in the `lhm-shopify` RBI.

## Note

I'm not sure we have a team consensus on what to do with centralized RBIs when Sorbet makes a breaking change. In my mind, the justification for making this change sooner rather than later is that by default, we'd like to support the "golden path" (updating quickly) and then we can provide extra guidance for those on older versions if necessary. I'm open to feedback though!

Once we agree on an approach, I can also find and fix instances in other gem RBIS.
