### PR TITLE
`stripe-ruby`: Add `Stripe::File` fields based on documentation

### DIFF
--- a/rbi/annotations/stripe.rbi
+++ b/rbi/annotations/stripe.rbi
@@ -533,6 +533,42 @@ class Stripe::File < Stripe::APIResource
 
   sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[Symbol, T.untyped])).returns(Stripe::File) }
   def self.retrieve(id, opts = nil); end
+
+  # @method_missing: from StripeObject
+  sig { returns(String) }
+  def purpose; end
+
+  # @method_missing: from StripeObject
+  sig { returns(String) }
+  def type; end
+
+  # @method_missing: from StripeObject
+  sig { returns(Integer) }
+  def created; end
+
+  # @method_missing: from StripeObject
+  sig { returns(T.nilable(Integer)) }
+  def expires_at; end
+
+  # @method_missing: from StripeObject
+  sig { returns(String) }
+  def filename; end
+
+  # @method_missing: from StripeObject
+  sig { returns(Stripe::ListObject) }
+  def links; end
+
+  # @method_missing: from StripeObject
+  sig { returns(Integer) }
+  def size; end
+
+  # @method_missing: from StripeObject
+  sig { returns(T.nilable(String)) }
+  def title; end
+
+  # @method_missing: from StripeObject
+  sig { returns(String) }
+  def url; end
 end
 
 class Stripe::ListObject


### PR DESCRIPTION
### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

Added all the fields that exist on `Stripe::File` thanks to `StripeObject#method_missing` based on the
[Stripe documentation](https://stripe.com/docs/api/files/object).

Used the examples to pick what should be `T.nilable` and what we can safely assume to be present.

#### Details

* Gem name: `stripe-ruby`
* Gem version: `8.5.0` (any really)
* Gem source: https://github.com/stripe/stripe-ruby
* Gem API doc: https://stripe.com/docs/api/files/object
* Tapioca version: N/A
* Sorbet version: N/A
