### PR TITLE
Fix signature for Money allocate_max_amounts

### DIFF
--- a/rbi/annotations/shopify-money.rbi
+++ b/rbi/annotations/shopify-money.rbi
@@ -150,7 +150,7 @@ class Money
   sig { params(splits: T::Array[Numeric], strategy: Symbol).returns(T::Array[Money]) }
   def allocate(splits, strategy); end
 
-  sig { params(maximums: T::Array[Numeric]).returns(T::Array[Money]) }
+  sig { params(maximums: T::Array[T.any(Money, Numeric, String)]).returns(T::Array[Money]) }
   def allocate_max_amounts(maximums); end
 
   sig { params(num: Numeric).returns(T::Array[Money]) }


### PR DESCRIPTION
### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

The method actually accepts a `Money` object or a `String` in addition to `Numeric`.