### PR TITLE
Relax strictness of annotation RBI files

### DIFF
--- a/gem/lib/rbi-central.rb
+++ b/gem/lib/rbi-central.rb
@@ -64,8 +64,11 @@ module RBICentral
       Include:
       - 'rbi/**/*'
 
-    Sorbet/StrictSigil:
+    Sorbet/ValidSigil:
       Enabled: true
+      MinimumStrictness: "true"
+      SuggestedStrictness: "true"
+      RequireSigilOnAllFiles: true
   YML
 
   class Error < StandardError; end

--- a/gem/lib/rbi-central.rb
+++ b/gem/lib/rbi-central.rb
@@ -69,6 +69,9 @@ module RBICentral
       MinimumStrictness: "true"
       SuggestedStrictness: "true"
       RequireSigilOnAllFiles: true
+
+    Sorbet/EnforceSignatures:
+      Enabled: true
   YML
 
   class Error < StandardError; end

--- a/gem/test/rbi-central/cli/check_rubocop_test.rb
+++ b/gem/test/rbi-central/cli/check_rubocop_test.rb
@@ -69,7 +69,7 @@ module RBICentral
           }
         JSON
         @repo.write_annotations_file!("gem1", <<~RBI)
-          # typed: true
+          # typed: false
 
           module Gem1; end
         RBI
@@ -85,9 +85,9 @@ module RBICentral
 
           Linting `gem1`...
 
-          Error: rbi/annotations/gem1.rbi:1:1: C: Sorbet/StrictSigil: Sorbet sigil should be at least strict got true.
-          # typed: true
-          ^^^^^^^^^^^^^
+          Error: rbi/annotations/gem1.rbi:1:1: C: Sorbet/ValidSigil: Sorbet sigil should be at least true got false.
+          # typed: false
+          ^^^^^^^^^^^^^^
 
           Linting `gem2`...
 
@@ -111,7 +111,7 @@ module RBICentral
           module Gem1; end
         RBI
         @repo.write_annotations_file!("gem2", <<~RBI)
-          # typed: true
+          # typed: false
 
           module Gem2; end
         RBI
@@ -121,9 +121,9 @@ module RBICentral
 
           Linting `gem2`...
 
-          Error: rbi/annotations/gem2.rbi:1:1: C: Sorbet/StrictSigil: Sorbet sigil should be at least strict got true.
-          # typed: true
-          ^^^^^^^^^^^^^
+          Error: rbi/annotations/gem2.rbi:1:1: C: Sorbet/ValidSigil: Sorbet sigil should be at least true got false.
+          # typed: false
+          ^^^^^^^^^^^^^^
 
           Some checks failed. See above for details.
         ERR

--- a/gem/test/rbi-central/cli/check_test.rb
+++ b/gem/test/rbi-central/cli/check_test.rb
@@ -121,10 +121,7 @@ module RBICentral
 
           Linting `gem1`...
 
-          Error: rbi/annotations/gem1.rbi:1:1: C: [Correctable] Sorbet/StrictSigil: No Sorbet sigil found in file. Try a typed: strict to start (you can also use rubocop -a to automatically add this).
-          class Gem1::NotFound; end
-          ^^^^^
-          rbi/annotations/gem1.rbi:1:1: C: [Correctable] Sorbet/ValidSigil: No Sorbet sigil found in file. Try a typed: true to start (you can also use rubocop -a to automatically add this).
+          Error: rbi/annotations/gem1.rbi:1:1: C: [Correctable] Sorbet/ValidSigil: No Sorbet sigil found in file. Try a typed: true to start (you can also use rubocop -a to automatically add this).
           class Gem1::NotFound; end
           ^^^^^
 

--- a/gem/test/rbi-central/repo_test.rb
+++ b/gem/test/rbi-central/repo_test.rb
@@ -143,15 +143,15 @@ module RBICentral
 
     def test_check_rubocop_for_invalid
       @repo.write_annotations_file!("gem1", <<~RBI)
-        # typed: true
+        # typed: false
 
         module Spoom; end
       RBI
       errors = @repo.check_rubocop_for(Gem.new(name: "gem1"))
       assert_equal(<<~ERR, errors.first&.message)
-        rbi/annotations/gem1.rbi:1:1: C: Sorbet/StrictSigil: Sorbet sigil should be at least strict got true.
-        # typed: true
-        ^^^^^^^^^^^^^
+        rbi/annotations/gem1.rbi:1:1: C: Sorbet/ValidSigil: Sorbet sigil should be at least true got false.
+        # typed: false
+        ^^^^^^^^^^^^^^
       ERR
     end
 

--- a/rbi/annotations/aasm.rbi
+++ b/rbi/annotations/aasm.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 module AASM
   mixes_in_class_methods(AASM::ClassMethods)

--- a/rbi/annotations/actionmailer.rbi
+++ b/rbi/annotations/actionmailer.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class ActionMailer::Base
   sig { params(headers: T.untyped, block: T.nilable(T.proc.void)).returns(Mail::Message) }

--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class ActionController::API
   MODULES = T.let(T.unsafe(nil), T::Array[T.untyped])

--- a/rbi/annotations/actionview.rbi
+++ b/rbi/annotations/actionview.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 
 module ActionView
   TemplateError = T.type_alias { Template::Error }

--- a/rbi/annotations/active_flag.rbi
+++ b/rbi/annotations/active_flag.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class ActiveRecord::Base
   # @shim: this is included at runtime https://github.com/kenn/active_flag/blob/master/lib/active_flag/railtie.rb#L6

--- a/rbi/annotations/activemodel.rbi
+++ b/rbi/annotations/activemodel.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class ActiveModel::Errors
   Elem = type_member { { fixed: ActiveModel::Error } }

--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class ActiveRecord::Schema
   sig {params(info: T::Hash[T.untyped, T.untyped], blk: T.proc.bind(ActiveRecord::Schema).void).void}

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 module ActiveSupport::Testing::Declarative
   sig { params(name: String, block: T.proc.bind(T.untyped).void).void }

--- a/rbi/annotations/aws-sdk-acm.rbi
+++ b/rbi/annotations/aws-sdk-acm.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class Aws::ACM::Client
   sig { params(params: T.untyped, options: T.untyped).returns(Aws::ACM::Types::DescribeCertificateResponse) }

--- a/rbi/annotations/bencode.rbi
+++ b/rbi/annotations/bencode.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class Array
   # Bencodes the Array object. Bencoded arrays are represented as +lxe+, where

--- a/rbi/annotations/colorize.rbi
+++ b/rbi/annotations/colorize.rbi
@@ -107,9 +107,6 @@ class String
   def red; end
 
   sig { returns(String) }
-  def swap; end
-
-  sig { returns(String) }
   def underline; end
 
   sig { returns(String) }

--- a/rbi/annotations/colorize.rbi
+++ b/rbi/annotations/colorize.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class String
   extend Colorize::ClassMethods

--- a/rbi/annotations/configs.rbi
+++ b/rbi/annotations/configs.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 
 module Configs
   sig { params(name: T.any(String, Symbol)).returns(ActiveSupport::HashWithIndifferentAccess) }

--- a/rbi/annotations/delayed_job.rbi
+++ b/rbi/annotations/delayed_job.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 
 module Delayed::MessageSending
   sig { params(options: T.nilable(T::Hash[Symbol, T.untyped])).returns(T.self_type) }

--- a/rbi/annotations/elasticsearch-dsl.rbi
+++ b/rbi/annotations/elasticsearch-dsl.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 module Elasticsearch::DSL::Search
   sig { params(args: T.untyped, block: T.proc.bind(Elasticsearch::DSL::Search::Search).void).void }

--- a/rbi/annotations/faraday.rbi
+++ b/rbi/annotations/faraday.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 module Faraday
   class << self

--- a/rbi/annotations/globalid.rbi
+++ b/rbi/annotations/globalid.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class ActiveRecord::Base
   # @shim: this is included at runtime https://github.com/rails/globalid/blob/v1.0.0/lib/global_id/railtie.rb#L38

--- a/rbi/annotations/graphql.rbi
+++ b/rbi/annotations/graphql.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 
 module GraphQL
   class << self

--- a/rbi/annotations/kredis.rbi
+++ b/rbi/annotations/kredis.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 module Kredis::Types
   sig { params(key: T.untyped, default: T.untyped, config: T.untyped, after_change: T.untyped, expires_in: T.untyped).returns(Kredis::Types::Scalar) }

--- a/rbi/annotations/lhm-shopify.rbi
+++ b/rbi/annotations/lhm-shopify.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 
 module Lhm
   extend Lhm

--- a/rbi/annotations/lhm.rbi
+++ b/rbi/annotations/lhm.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 
 module Lhm
   extend Lhm

--- a/rbi/annotations/mocha.rbi
+++ b/rbi/annotations/mocha.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 module Mocha::API
   sig { params(arguments: T.untyped).returns(Mocha::Mock) }

--- a/rbi/annotations/parse-cron.rbi
+++ b/rbi/annotations/parse-cron.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 # Parses cron expressions and computes the next occurence of the "job"
 class CronParser

--- a/rbi/annotations/pundit.rbi
+++ b/rbi/annotations/pundit.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 module Pundit::Authorization
   sig { void }

--- a/rbi/annotations/railties.rbi
+++ b/rbi/annotations/railties.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 
 module Rails
   class << self

--- a/rbi/annotations/rainbow.rbi
+++ b/rbi/annotations/rainbow.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 module Rainbow
   # @shim: https://github.com/sickill/rainbow/blob/master/lib/rainbow.rb#L10-L12

--- a/rbi/annotations/shopify-money.rbi
+++ b/rbi/annotations/shopify-money.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 
 class Money
   sig { returns(BigDecimal) }

--- a/rbi/annotations/sidekiq-scheduler.rbi
+++ b/rbi/annotations/sidekiq-scheduler.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 
 class SidekiqScheduler::Scheduler
   # @shim: Instance methods are made to function as class methods using `method_missing`

--- a/rbi/annotations/sidekiq.rbi
+++ b/rbi/annotations/sidekiq.rbi
@@ -11,7 +11,10 @@ end
 class Sidekiq::Client
   private
 
+  sig { params(item: T.untyped).returns(T.untyped) }
   def normalize_item(item); end
+
+  sig { params(item_class: T.untyped).returns(T.untyped) }
   def normalized_hash(item_class); end
 end
 

--- a/rbi/annotations/sidekiq.rbi
+++ b/rbi/annotations/sidekiq.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class Sidekiq::CLI
   sig { returns(Sidekiq::CLI) }

--- a/rbi/annotations/state_machines.rbi
+++ b/rbi/annotations/state_machines.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class StateMachines::Machine
   include StateMachines::MatcherHelpers

--- a/rbi/annotations/stripe.rbi
+++ b/rbi/annotations/stripe.rbi
@@ -498,6 +498,7 @@ class Stripe::Invoice < Stripe::APIResource
   def subtotal; end
 
   # @method_missing: from StripeObject
+  sig { returns(T::Hash[T.untyped, T.untyped]) }
   def status_transitions; end
 end
 
@@ -525,6 +526,7 @@ class Stripe::InvoiceItem < Stripe::APIResource
 
   # unsure how to represent a StripeObject with specific keys/mmethods without causing typing errors
   # @method_missing: from StripeObject
+  sig { returns(T::Hash[T.untyped, T.untyped]) }
   def period; end
 end
 
@@ -648,6 +650,7 @@ class Stripe::Plan < Stripe::APIResource
 
   # unsure how to represent a StripeObject with specific keys/mmethods without causing typing errors
   # @method_missing: from StripeObject
+  sig { returns(T::Hash[T.untyped, T.untyped]) }
   def period; end
 
   # @method_missing: from StripeObject

--- a/rbi/annotations/stripe.rbi
+++ b/rbi/annotations/stripe.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class Stripe::APIResource < Stripe::StripeObject
   Elem = type_member { { fixed: T.untyped } }

--- a/rbi/annotations/webmock.rbi
+++ b/rbi/annotations/webmock.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 
 class Minitest::Test
   include WebMock::API


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

I changed all the annotation files to `typed: true` since anything above that is useless for annotation RBI files for two reasons:
1. There is nothing the end-user can do if the annotation RBI file has errors at the higher strictness levels. It causes confusion, and makes end-users override the strictness in their config to work around it. This is related to #168
2. [As per my comment in #168](https://github.com/Shopify/rbi-central/pull/168#issuecomment-1591387996), as of today, Sorbet does not error for methods missing signatures in RBI files that are at `typed: strict` or above. That means that we hadn't been enforcing signatures to exist until now anyway.

So the changes I've made can be read commit by commit and are:

1. Change all annotation RBI file strictness levels to be `typed: true` and force it to be so for all RBI files via the `rubocop` check.
2. Use the `Sorbet/EnforceSignatures` cop to error for any methods that don't have signatures
3. Fix existing errors related to methods and missing signatures