### PR TITLE
Use exact `true` strictness for annotation RBI files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       parser (>= 3.1.1.0)
     rubocop-shopify (2.10.1)
       rubocop (~> 1.35)
-    rubocop-sorbet (0.6.11)
+    rubocop-sorbet (0.7.1)
       rubocop (>= 0.90.0)
     ruby-progressbar (1.11.0)
     sorbet (0.5.10601)

--- a/gem/lib/rbi-central.rb
+++ b/gem/lib/rbi-central.rb
@@ -66,7 +66,7 @@ module RBICentral
 
     Sorbet/ValidSigil:
       Enabled: true
-      MinimumStrictness: "true"
+      ExactStrictness: "true"
       SuggestedStrictness: "true"
       RequireSigilOnAllFiles: true
 

--- a/gem/test/rbi-central/cli/check_rubocop_test.rb
+++ b/gem/test/rbi-central/cli/check_rubocop_test.rb
@@ -14,12 +14,12 @@ module RBICentral
           }
         JSON
         @repo.write_annotations_file!("gem1", <<~RBI)
-          # typed: strict
+          # typed: true
 
           module Gem1; end
         RBI
         @repo.write_annotations_file!("gem2", <<~RBI)
-          # typed: strict
+          # typed: true
 
           module Gem2; end
         RBI
@@ -46,7 +46,7 @@ module RBICentral
           module Gem1; end
         RBI
         @repo.write_annotations_file!("gem2", <<~RBI)
-          # typed: strict
+          # typed: true
 
           module Gem2; end
         RBI
@@ -69,12 +69,12 @@ module RBICentral
           }
         JSON
         @repo.write_annotations_file!("gem1", <<~RBI)
-          # typed: false
+          # typed: strict
 
           module Gem1; end
         RBI
         @repo.write_annotations_file!("gem2", <<~RBI)
-          # typed: strict
+          # typed: true
 
           module Gem2
           end
@@ -85,9 +85,9 @@ module RBICentral
 
           Linting `gem1`...
 
-          Error: rbi/annotations/gem1.rbi:1:1: C: Sorbet/ValidSigil: Sorbet sigil should be at least true got false.
-          # typed: false
-          ^^^^^^^^^^^^^^
+          Error: rbi/annotations/gem1.rbi:1:1: C: Sorbet/ValidSigil: Sorbet sigil should be true got strict.
+          # typed: strict
+          ^^^^^^^^^^^^^^^
 
           Linting `gem2`...
 
@@ -121,7 +121,7 @@ module RBICentral
 
           Linting `gem2`...
 
-          Error: rbi/annotations/gem2.rbi:1:1: C: Sorbet/ValidSigil: Sorbet sigil should be at least true got false.
+          Error: rbi/annotations/gem2.rbi:1:1: C: Sorbet/ValidSigil: Sorbet sigil should be true got false.
           # typed: false
           ^^^^^^^^^^^^^^
 

--- a/gem/test/rbi-central/cli/check_test.rb
+++ b/gem/test/rbi-central/cli/check_test.rb
@@ -18,14 +18,14 @@ module RBICentral
           }
         JSON
         @repo.write_annotations_file!("gem1", <<~RBI)
-          # typed: strict
+          # typed: true
 
           module Gem1
             abstract!
           end
         RBI
         @repo.write_annotations_file!("gem2", <<~RBI)
-          # typed: strict
+          # typed: true
 
           module Gem2
             abstract!
@@ -86,7 +86,7 @@ module RBICentral
           class Gem1::NotFound; end
         RBI
         @repo.write_annotations_file!("gem2", <<~RBI)
-          # typed: strict
+          # typed: true
 
           module Gem2
             abstract!

--- a/gem/test/rbi-central/repo_test.rb
+++ b/gem/test/rbi-central/repo_test.rb
@@ -134,7 +134,7 @@ module RBICentral
 
     def test_check_rubocop_for_valid
       @repo.write_annotations_file!("gem1", <<~RBI)
-        # typed: strict
+        # typed: true
 
         module Spoom; end
       RBI
@@ -143,15 +143,15 @@ module RBICentral
 
     def test_check_rubocop_for_invalid
       @repo.write_annotations_file!("gem1", <<~RBI)
-        # typed: false
+        # typed: strict
 
         module Spoom; end
       RBI
       errors = @repo.check_rubocop_for(Gem.new(name: "gem1"))
       assert_equal(<<~ERR, errors.first&.message)
-        rbi/annotations/gem1.rbi:1:1: C: Sorbet/ValidSigil: Sorbet sigil should be at least true got false.
-        # typed: false
-        ^^^^^^^^^^^^^^
+        rbi/annotations/gem1.rbi:1:1: C: Sorbet/ValidSigil: Sorbet sigil should be true got strict.
+        # typed: strict
+        ^^^^^^^^^^^^^^^
       ERR
     end
 


### PR DESCRIPTION
### Type of Change

Infrastructure change

### Changes

This PR uses the newly released `ExactStrictness` option of `Sorbet/ValidSigil` cop to ensure that all annotation RBIs are at `typed: true` strictness exactly.