### PR TITLE
Fix sig for `Money#/`

### DIFF
--- a/rbi/annotations/shopify-money.rbi
+++ b/rbi/annotations/shopify-money.rbi
@@ -108,7 +108,7 @@ class Money
   sig { params(numeric: Numeric).returns(Money) }
   def *(numeric); end
 
-  sig { params(numeric: Numeric).returns(T.noreturn) }
+  sig { params(numeric: T.untyped).returns(T.noreturn) }
   def /(numeric); end
 
   sig { returns(String) }


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

This method raises no matter the input: https://github.com/Shopify/money/blob/839725727f5ffc27c75c3ff12ca9deb10b575cca/lib/money/money.rb#L151

So we can simplify the sig to make the Sorbet error more clear.