### PR TITLE
`Money#clamp` accepts Numeric or Money arguments

### DIFF
--- a/rbi/annotations/shopify-money.rbi
+++ b/rbi/annotations/shopify-money.rbi
@@ -159,7 +159,7 @@ class Money
   sig { params(num: Numeric).returns(T::Hash[Money, Numeric]) }
   def calculate_splits(num); end
 
-  sig { params(min: Numeric, max: Numeric).returns(Money) }
+  sig { params(min: T.any(Numeric, Money), max: T.any(Numeric, Money)).returns(Money) }
   def clamp(min, max); end
 end
 


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

Proof:

```
2.7.7 :004 > Money.new(0, "USD").clamp(Money.new(1, "USD"), Money.new(10, "USD"))
 => #<Money value:1.00 currency:USD>
2.7.7 :005 > Money.new(0, "USD").clamp(1, 10)
 => #<Money value:1.00 currency:USD>
```