### PR TITLE
Add annotations for rspec

### DIFF
--- a/index.json
+++ b/index.json
@@ -107,6 +107,22 @@
       "rainbow/version"
     ]
   },
+  "rspec-core": {
+    "dependencies": [
+      "rspec"
+    ],
+    "requires": [
+      "rspec"
+    ]
+  },
+  "rspec-expectations": {
+    "dependencies": [
+      "rspec"
+    ],
+    "requires": [
+      "rspec"
+    ]
+  },
   "shopify-money": {
     "requires": [
       "money"

--- a/rbi/annotations/rspec-core.rbi
+++ b/rbi/annotations/rspec-core.rbi
@@ -1,0 +1,11 @@
+# typed: true
+
+class RSpec::Core::ExampleGroup
+  class << self
+    sig { params(args: T.untyped, example_group_block: T.proc.bind(T.untyped).void).void }
+    def describe(*args, &example_group_block); end
+
+    sig { params(all_args: T.untyped, block: T.proc.bind(RSpec::Matchers).void).void }
+    def it(*all_args, &block); end
+  end
+end

--- a/rbi/annotations/rspec-core.rbi
+++ b/rbi/annotations/rspec-core.rbi
@@ -2,7 +2,7 @@
 
 class RSpec::Core::ExampleGroup
   class << self
-    sig { params(args: T.untyped, example_group_block: T.proc.bind(T.untyped).void).void }
+    sig { params(args: T.untyped, example_group_block: T.proc.bind(T.class_of(RSpec::Core::ExampleGroup)).void).void }
     def describe(*args, &example_group_block); end
 
     sig { params(all_args: T.untyped, block: T.proc.bind(RSpec::Matchers).void).void }

--- a/rbi/annotations/rspec-expectations.rbi
+++ b/rbi/annotations/rspec-expectations.rbi
@@ -1,0 +1,8 @@
+# typed: true
+
+module RSpec
+  class << self
+    sig { params(args: T.untyped, example_group_block: T.proc.bind(T.class_of(RSpec::Core::ExampleGroup)).void).void }
+    def describe(*args, &example_group_block); end
+  end
+end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name:
  * rspec-core
  * rspec-expectations
* Gem version:
  * rspec-core@3.12.2
  * rspec-expectations@3.12.3
* Gem source: 
  * rspec-core: https://github.com/rspec/rspec-core
  * rspec-expectations: https://github.com/rspec/rspec-expectations
* Gem API doc: <!-- Link relevant API doc from the gem for the problem you have -->
  * rspec-core: http://rspec.info/documentation/3.12/rspec-core/
  * rspec-expectations: http://rspec.info/documentation/3.12/rspec-expectations/
* Tapioca version: v0.11.8
* Sorbet version: Sorbet typechecker 0.5.10962 git 7640040cafd310be03c3d8d087744740b46487f1 debug_symbols=true clean=1
