### PR TITLE
add basic devise annotation

### DIFF
--- a/index.json
+++ b/index.json
@@ -49,6 +49,8 @@
   },
   "delayed_job": {
   },
+  "devise": {
+  },
   "elasticsearch-dsl": {
     "requires": [
       "elasticsearch/dsl"

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -97,5 +97,23 @@ class Devise::SessionsController < DeviseController
   def sign_in_params; end
 end
 
-class Devise::UnlocksController< DeviseController
+class Devise::UnlocksController < DeviseController
+ # GET /resource/unlock/new
+  def new; end
+
+  # POST /resource/unlock
+  def create; end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  def show; end
+
+  protected
+
+  # The path used after sending unlock password instructions
+  sig {params(resource: T.untyped).returns(String)}
+  def after_sending_unlock_instructions_path_for(resource); end
+
+  sig {params(resource: T.untyped).returns(String)}
+  # The path used after unlocking the resource
+  def after_unlock_path_for(resource); end
 end

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -1,5 +1,40 @@
 # typed: true
 
+class DeviseController
+  protected
+
+  sig {returns(T.untyped)}
+  def resource; end
+
+  # Proxy to devise map name
+  sig {returns(String)}
+  def resource_name; end
+
+  sig {returns(String)}
+  def scope_name; end
+
+  # Proxy to devise map class
+  sig {returns(T::Class[T.anything])}
+  def resource_class; end
+
+  # Returns a signed in resource from session (if one exists)
+  sig {returns(T.untyped)}
+  def signed_in_resource; end
+
+  # Attempt to find the mapped route for devise based on request path
+  sig {returns(T.untyped)}
+  def devise_mapping; end
+
+  sig {returns(T.untyped)}
+  def navigational_formats; end
+
+  sig {returns(ActionController::Parameters)}
+  def resource_params; end
+
+  sig {returns(String)}
+  def translation_scope; end
+end
+
 class Devise::ConfirmationsController < DeviseController
 end
 

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -1,0 +1,16 @@
+# typed: true
+
+class Devise::ConfirmationsController < DeviseController
+end
+
+class Devise::PasswordsController< DeviseController
+end
+
+class Devise::RegistrationsController< DeviseController
+end
+
+class Devise::SessionsController< DeviseController
+end
+
+class Devise::UnlocksController< DeviseController
+end

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -114,13 +114,14 @@ class Devise::SessionsController < DeviseController
   def destroy; end
 
   protected
+
   sig { returns(ActionController::Parameters)}
   def sign_in_params; end
 end
 
 # @shim: Devise controllers are loaded by rails
 class Devise::UnlocksController < DeviseController
- # GET /resource/unlock/new
+  # GET /resource/unlock/new
   sig {returns(T.untyped)}
   def new; end
 

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -36,42 +36,54 @@ class DeviseController
 end
 
 class Devise::ConfirmationsController < DeviseController
+  sig {returns(T.untyped)}
   def new; end
   # POST /resource/confirmation
+  sig {returns(T.untyped)}
   def create; end
   # GET /resource/confirmation?confirmation_token=abcdef
+  sig {returns(T.untyped)}
   def show; end
 end
 
 class Devise::PasswordsController < DeviseController
- # GET /resource/password/new
+  # GET /resource/password/new
+  sig {returns(T.untyped)}
   def new; end
 
   # POST /resource/password
+  sig {returns(T.untyped)}
   def create; end
 
   # GET /resource/password/edit?reset_password_token=abcdef
+  sig {returns(T.untyped)}
   def edit; end
 
   # PUT /resource/password
+  sig {returns(T.untyped)}
   def update; end
 end
 
 class Devise::RegistrationsController < DeviseController
+  sig {returns(T.untyped)}
   def new; end
 
   # POST /resource
+  sig {returns(T.untyped)}
   def create; end
 
   # GET /resource/edit
+  sig {returns(T.untyped)}
   def edit; end
 
   # PUT /resource
   # We need to use a copy of the resource because we don't want to change
   # the current user in place.
+  sig {returns(T.untyped)}
   def update; end
 
   # DELETE /resource
+  sig {returns(T.untyped)}
   def destroy; end
 
   # GET /resource/cancel
@@ -79,17 +91,21 @@ class Devise::RegistrationsController < DeviseController
   # in to be expired now. This is useful if the user wants to
   # cancel oauth signing in/up in the middle of the process,
   # removing all OAuth session data.
+  sig {returns(T.untyped)}
   def cancel; end
 end
 
 class Devise::SessionsController < DeviseController
   # GET /resource/sign_in
+  sig {returns(T.untyped)}
   def new; end
 
   # POST /resource/sign_in
+  sig {returns(T.untyped)}
   def create; end
 
   # DELETE /resource/sign_out
+  sig {returns(T.untyped)}
   def destroy; end
 
   protected
@@ -99,12 +115,15 @@ end
 
 class Devise::UnlocksController < DeviseController
  # GET /resource/unlock/new
+  sig {returns(T.untyped)}
   def new; end
 
   # POST /resource/unlock
+  sig {returns(T.untyped)}
   def create; end
 
   # GET /resource/unlock?unlock_token=abcdef
+  sig {returns(T.untyped)}
   def show; end
 
   protected

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -1,5 +1,6 @@
 # typed: true
 
+# @shim: Devise controllers are loaded by rails
 class DeviseController
   protected
 
@@ -35,6 +36,7 @@ class DeviseController
   def translation_scope; end
 end
 
+# @shim: Devise controllers are loaded by rails
 class Devise::ConfirmationsController < DeviseController
   sig {returns(T.untyped)}
   def new; end
@@ -46,6 +48,7 @@ class Devise::ConfirmationsController < DeviseController
   def show; end
 end
 
+# @shim: Devise controllers are loaded by rails
 class Devise::PasswordsController < DeviseController
   # GET /resource/password/new
   sig {returns(T.untyped)}
@@ -64,6 +67,7 @@ class Devise::PasswordsController < DeviseController
   def update; end
 end
 
+# @shim: Devise controllers are loaded by rails
 class Devise::RegistrationsController < DeviseController
   sig {returns(T.untyped)}
   def new; end
@@ -95,6 +99,7 @@ class Devise::RegistrationsController < DeviseController
   def cancel; end
 end
 
+# @shim: Devise controllers are loaded by rails
 class Devise::SessionsController < DeviseController
   # GET /resource/sign_in
   sig {returns(T.untyped)}
@@ -113,6 +118,7 @@ class Devise::SessionsController < DeviseController
   def sign_in_params; end
 end
 
+# @shim: Devise controllers are loaded by rails
 class Devise::UnlocksController < DeviseController
  # GET /resource/unlock/new
   sig {returns(T.untyped)}

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -57,7 +57,29 @@ class Devise::PasswordsController < DeviseController
   def update; end
 end
 
-class Devise::RegistrationsController< DeviseController
+class Devise::RegistrationsController < DeviseController
+  def new; end
+
+  # POST /resource
+  def create; end
+
+  # GET /resource/edit
+  def edit; end
+
+  # PUT /resource
+  # We need to use a copy of the resource because we don't want to change
+  # the current user in place.
+  def update; end
+
+  # DELETE /resource
+  def destroy; end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  def cancel; end
 end
 
 class Devise::SessionsController< DeviseController

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -43,7 +43,18 @@ class Devise::ConfirmationsController < DeviseController
   def show; end
 end
 
-class Devise::PasswordsController< DeviseController
+class Devise::PasswordsController < DeviseController
+ # GET /resource/password/new
+  def new; end
+
+  # POST /resource/password
+  def create; end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  def edit; end
+
+  # PUT /resource/password
+  def update; end
 end
 
 class Devise::RegistrationsController< DeviseController

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -36,6 +36,11 @@ class DeviseController
 end
 
 class Devise::ConfirmationsController < DeviseController
+  def new; end
+  # POST /resource/confirmation
+  def create; end
+  # GET /resource/confirmation?confirmation_token=abcdef
+  def show; end
 end
 
 class Devise::PasswordsController< DeviseController

--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -82,7 +82,19 @@ class Devise::RegistrationsController < DeviseController
   def cancel; end
 end
 
-class Devise::SessionsController< DeviseController
+class Devise::SessionsController < DeviseController
+  # GET /resource/sign_in
+  def new; end
+
+  # POST /resource/sign_in
+  def create; end
+
+  # DELETE /resource/sign_out
+  def destroy; end
+
+  protected
+  sig { returns(ActionController::Parameters)}
+  def sign_in_params; end
 end
 
 class Devise::UnlocksController< DeviseController


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ x ] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

* Gem name: Devise
* Gem version: 4.9.3
* Gem source: https://github.com/heartcombo/devise
* Tapioca version: 0.11.9
* Sorbet version: 0.5.11074

This adds some very basic annotations for devise. Prior to tapioca 0.11.8 tapioca would generate rbis for Devise::SessionsController, Devise::RegistrationsController etc. (so that it could define helper related modules on them). As of tapioca 0.11.9 this is no longer the case, so subclasses of devise controllers cause a sorbet error whatever the type checking level requested on those files since the parent class is not known to sorbet.

I also added the actions for each controllers and the core devise controller methods