### PR TITLE
Type blank?/present? for Active Record models

### DIFF
--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -183,4 +183,10 @@ class ActiveRecord::Base
     ).void
   end
   def self.after_rollback(*args, **options, &block); end
+
+  sig { returns(FalseClass) }
+  def blank?; end
+
+  sig { returns(TrueClass) }
+  def present?; end
 end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

This allows Sorbet to warn about unreachable code where a non-nilable model instance is used in a conditional with an else clause. Something like:

```ruby
sig { returns(T.nilable(User)) }
def current_user # e.g. Devise
  User.find_by(id: session[:user_id])
end 

sig { returns(User) }
def current_user!
  T.must(current_user)
end

# somewhere further away in the code

if current_user!.present? # GitHub Copilot seems eager to suggest present? checks
  do_one_thing
else
  do_other_thing # unreachable code https://sorbet.org/docs/error-reference#7006
end
```

* Gem name: Active Record
* Gem version: 6.0+
* Gem source: https://github.com/rails/rails/blob/08473e3898b7faa163a5849bae61ac698e41981e/activerecord/lib/active_record/core.rb#L611-L617