### PR TITLE
Add annotations for `opentelemetry-sdk`

### DIFF
--- a/index.json
+++ b/index.json
@@ -88,6 +88,8 @@
       "mocha/api"
     ]
   },
+  "opentelemetry-sdk": {
+  },
   "parse-cron": {
   },
   "pundit": {

--- a/rbi/annotations/opentelemetry-sdk.rbi
+++ b/rbi/annotations/opentelemetry-sdk.rbi
@@ -1,0 +1,34 @@
+# typed: true
+
+module OpenTelemetry
+  sig { returns(OpenTelemetry::Trace::TracerProvider) }
+  def self.tracer_provider; end
+end
+
+class OpenTelemetry::Trace::TracerProvider
+  sig { params(name: T.nilable(String), version: T.nilable(String)).returns(OpenTelemetry::Trace::Tracer) }
+  def tracer(name = nil, version = nil); end
+end
+
+class OpenTelemetry::Trace::Tracer
+  sig do
+    params(
+      name: String,
+      with_parent: T.nilable(OpenTelemetry::Trace::Span),
+      attributes: T.nilable(T::Hash[String, T.untyped]),
+      links: T.nilable(T::Array[OpenTelemetry::Trace::Link]),
+      start_timestamp: T.nilable(Integer),
+      kind: T.nilable(Symbol)
+    )
+      .returns(OpenTelemetry::Trace::Span)
+  end
+  def start_span(name, with_parent: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil); end
+end
+
+class OpenTelemetry::Trace::Span
+  sig { params(key: String, value: T.untyped).returns(T.self_type) }
+  def set_attribute(key, value); end
+
+  sig { params(end_timestamp: Integer).void }
+  def finish(end_timestamp: nil); end
+end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: opentelemetry-sdk
* Gem version: 1.3.1
* Gem source: https://github.com/open-telemetry/opentelemetry-ruby/tree/opentelemetry-sdk/v1.3.1/sdk
* Gem API doc: https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v1.3.1/
* Tapioca version: 0.11.4
* Sorbet version: 0.5.10601
