### PR TITLE
Disable dependabot for root directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    reviewers:
-      - "Shopify/sorbet"
-    labels:
-      - "dependencies"
-  - package-ecosystem: "bundler"
     directory: "/gem"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
All the gems come from `rbi-central` that is loaded from the local path `gem/` we shouldn't need any gem bump at the root level.