### PR TITLE
Annotations for Active Support error reporter

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -427,3 +427,43 @@ class String
   sig { returns(String) }
   def upcase_first; end
 end
+
+class ActiveSupport::ErrorReporter
+  sig do
+    type_parameters(:Block, :Fallback)
+      .params(
+        error_classes: T.class_of(Exception),
+        severity: T.nilable(Symbol),
+        context: T.nilable(T::Hash[Symbol, T.untyped]),
+        fallback: T.nilable(T.proc.returns(T.type_parameter(:Fallback))),
+        source: T.nilable(String),
+        blk: T.proc.returns(T.type_parameter(:Block)),
+      )
+      .returns(T.any(T.type_parameter(:Block), T.type_parameter(:Fallback)))
+  end
+  def handle(*error_classes, severity: :warning, context: {}, fallback: nil, source: DEFAULT_SOURCE, &blk); end
+
+  sig do
+    type_parameters(:Block)
+      .params(
+        error_classes: T.class_of(Exception),
+        severity: T.nilable(Symbol),
+        context: T.nilable(T::Hash[Symbol, T.untyped]),
+        source: T.nilable(String),
+        blk: T.proc.returns(T.type_parameter(:Block)),
+      )
+      .returns(T.type_parameter(:Block))
+  end
+  def record(*error_classes, severity: :error, context: {}, source: DEFAULT_SOURCE, &blk); end
+
+  sig do
+    params(
+      error: Exception,
+      handled: T::Boolean,
+      severity: T.nilable(Symbol),
+      context: T::Hash[Symbol, T.untyped],
+      source: T.nilable(String),
+    ).void
+  end
+  def report(error, handled: true, severity: handled ? :warning : :error, context: {}, source: DEFAULT_SOURCE); end
+end

--- a/rbi/annotations/railties.rbi
+++ b/rbi/annotations/railties.rbi
@@ -14,6 +14,9 @@ module Rails
     sig { returns(ActiveSupport::EnvironmentInquirer) }
     def env; end
 
+    sig { returns(ActiveSupport::ErrorReporter) }
+    def error; end
+
     sig { returns(ActiveSupport::Logger) }
     def logger; end
 


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: Active Support
* Gem version: 7.1.3
* Gem source: https://github.com/rails/rails/blob/v7.1.3/activesupport/lib/active_support/error_reporter.rb
* Gem API doc: https://api.rubyonrails.org/v7.1.3/classes/ActiveSupport/ErrorReporter.html
* Tapioca version: <!-- Add the version of Tapioca you use -->
* Sorbet version: <!-- Add the version of Sorbet you use -->
