### PR TITLE
Remove `DEFAULT_SOURCE` from Active Support RBI

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -441,7 +441,7 @@ class ActiveSupport::ErrorReporter
       )
       .returns(T.any(T.type_parameter(:Block), T.type_parameter(:Fallback)))
   end
-  def handle(*error_classes, severity: :warning, context: {}, fallback: nil, source: DEFAULT_SOURCE, &blk); end
+  def handle(*error_classes, severity: :warning, context: {}, fallback: nil, source: nil, &blk); end
 
   sig do
     type_parameters(:Block)
@@ -454,7 +454,7 @@ class ActiveSupport::ErrorReporter
       )
       .returns(T.type_parameter(:Block))
   end
-  def record(*error_classes, severity: :error, context: {}, source: DEFAULT_SOURCE, &blk); end
+  def record(*error_classes, severity: :error, context: {}, source: nil, &blk); end
 
   sig do
     params(
@@ -465,5 +465,5 @@ class ActiveSupport::ErrorReporter
       source: T.nilable(String),
     ).void
   end
-  def report(error, handled: true, severity: handled ? :warning : :error, context: {}, source: DEFAULT_SOURCE); end
+  def report(error, handled: true, severity: handled ? :warning : :error, context: {}, source: nil); end
 end

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -429,6 +429,8 @@ class String
 end
 
 class ActiveSupport::ErrorReporter
+  # The `source` parameter should actually point to the `DEFAULT_SOURCE` constant, but that doesn't
+  # exist for older versions of Rails, so we're inlining the string directly
   sig do
     type_parameters(:Block, :Fallback)
       .params(
@@ -441,8 +443,10 @@ class ActiveSupport::ErrorReporter
       )
       .returns(T.any(T.type_parameter(:Block), T.type_parameter(:Fallback)))
   end
-  def handle(*error_classes, severity: :warning, context: {}, fallback: nil, source: nil, &blk); end
+  def handle(*error_classes, severity: :warning, context: {}, fallback: nil, source: "application", &blk); end
 
+  # The `source` parameter should actually point to the `DEFAULT_SOURCE` constant, but that doesn't
+  # exist for older versions of Rails, so we're inlining the string directly
   sig do
     type_parameters(:Block)
       .params(
@@ -454,8 +458,10 @@ class ActiveSupport::ErrorReporter
       )
       .returns(T.type_parameter(:Block))
   end
-  def record(*error_classes, severity: :error, context: {}, source: nil, &blk); end
+  def record(*error_classes, severity: :error, context: {}, source: "application", &blk); end
 
+  # The `source` parameter should actually point to the `DEFAULT_SOURCE` constant, but that doesn't
+  # exist for older versions of Rails, so we're inlining the string directly
   sig do
     params(
       error: Exception,
@@ -465,5 +471,5 @@ class ActiveSupport::ErrorReporter
       source: T.nilable(String),
     ).void
   end
-  def report(error, handled: true, severity: handled ? :warning : :error, context: {}, source: nil); end
+  def report(error, handled: true, severity: handled ? :warning : :error, context: {}, source: "application"); end
 end


### PR DESCRIPTION
In #221, we added some new signatures for new Rails methods. However, the `DEFAULT_SOURCE` constant doesn't exist on older versions of Rails, which results in a type checking error.

I put `nil` instead of a random string. It's not correct, but using a random string didn't feel right either. Let me know if you have a different preference.

### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

