### PR TITLE
Use unsafe nil for default values

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -441,7 +441,7 @@ class ActiveSupport::ErrorReporter
       )
       .returns(T.any(T.type_parameter(:Block), T.type_parameter(:Fallback)))
   end
-  def handle(*error_classes, severity: T.unsafe(nil), context: T.unsafe(nil), fallback: nil, source: T.unsafe(nil), &blk); end
+  def handle(*error_classes, severity: T.unsafe(nil), context: T.unsafe(nil), fallback: T.unsafe(nil), source: T.unsafe(nil), &blk); end
 
   sig do
     type_parameters(:Block)
@@ -454,7 +454,7 @@ class ActiveSupport::ErrorReporter
       )
       .returns(T.type_parameter(:Block))
   end
-  def record(*error_classes, severity: T.unsafe(nil), context: {}, source: T.unsafe(nil), &blk); end
+  def record(*error_classes, severity: T.unsafe(nil), context: T.unsafe(nil), source: T.unsafe(nil), &blk); end
 
   sig do
     params(
@@ -465,5 +465,5 @@ class ActiveSupport::ErrorReporter
       source: T.nilable(String),
     ).void
   end
-  def report(error, handled: true, severity: T.unsafe(nil), context: {}, source: T.unsafe(nil)); end
+  def report(error, handled: true, severity: T.unsafe(nil), context: T.unsafe(nil), source: T.unsafe(nil)); end
 end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

Addressing https://github.com/Shopify/rbi-central/pull/222#pullrequestreview-1884118686, which I agree. It's hard to use default values in RBIs and we should favour `T.unsafe(nil)`. It might even be worth adding some CI check for that in the future.