### PR TITLE
Annotate ActionController::Parameters#require

### DIFF
--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -111,7 +111,8 @@ class ActionController::Parameters
   sig { params(key: T.any(String, Symbol)).returns(T.untyped) }
   def [](key); end
 
-  sig { params(key: T.any(String, Symbol, T::Array[T.any(String, Symbol)])).returns(T.untyped) }
+  sig { params(key: T.any(String, Symbol)).returns(ActionController::Parameters) }
+  sig { params(key: T::Array[T.any(String, Symbol)]).returns(T::Array[ActionController::Parameters]) }
   def require(key); end
 
   # required is an alias of require


### PR DESCRIPTION
### Type of Change

This can now be typed properly with overloaded signatures.

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

* Gem name: Action Pack
* Gem source: https://github.com/rails/rails/blob/36c1591bcb5e0ee3084759c7f42a706fe5bb7ca7/actionpack/lib/action_controller/metal/strong_parameters.rb#L517-L525
* Gem API doc: https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-require
