### PR TITLE
Change ActiveSupport::ErrorReporter#report to return NilClass

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -463,7 +463,7 @@ class ActiveSupport::ErrorReporter
       severity: T.nilable(Symbol),
       context: T::Hash[Symbol, T.untyped],
       source: T.nilable(String),
-    ).void
+    ).returns(NilClass)
   end
   def report(error, handled: true, severity: T.unsafe(nil), context: T.unsafe(nil), source: T.unsafe(nil)); end
 end


### PR DESCRIPTION
Follow-up to https://github.com/Shopify/rbi-central/pull/221 

This is what it actually returns and makes error reporting at the end of a method that returns `T.nilable(MyModel)` easier - I don't have to put `nil` return values myself anymore.

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: Active Support
* Gem version: 7.1.3
* Gem source: https://github.com/rails/rails/blob/v7.1.3/activesupport/lib/active_support/error_reporter.rb#L200