### PR TITLE
Set signature for `required` alias to same as original in `ActionController::Parameters`

### DIFF
--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -116,7 +116,8 @@ class ActionController::Parameters
   def require(key); end
 
   # required is an alias of require
-  sig { params(key: T.any(String, Symbol, T::Array[T.any(String, Symbol)])).returns(T.untyped) }
+  sig { params(key: T.any(String, Symbol)).returns(ActionController::Parameters) }
+  sig { params(key: T::Array[T.any(String, Symbol)]).returns(T::Array[ActionController::Parameters]) }
   def required(key); end
 
   sig { params(other_hash: T.untyped).returns(ActionController::Parameters) }


### PR DESCRIPTION
cc @bdewater

Follow-up from https://github.com/Shopify/rbi-central/pull/224, spotted by @erikaleigh 