### PR TITLE
Updates ActionMailer.mail block param's type to include its param type

### DIFF
--- a/rbi/annotations/actionmailer.rbi
+++ b/rbi/annotations/actionmailer.rbi
@@ -1,6 +1,11 @@
 # typed: true
 
 class ActionMailer::Base
-  sig { params(headers: T.untyped, block: T.nilable(T.proc.void)).returns(Mail::Message) }
+  sig do
+    params(
+      headers: T.untyped,
+      block: T.nilable(T.proc.params(arg0: ActionMailer::Collector).void)
+    ).returns(Mail::Message)
+  end
   def mail(headers = nil, &block); end
 end


### PR DESCRIPTION
### Description

Upgrading our app to rails 7.1.2 caused new sorbet issues with [our usage of ActionMailer.mail](https://github.com/Shopify/fbs/blob/8c0b7501977c6f72d724a9bbc94ddb0755889d9c/components/returns/app/mailers/returns/network_return_confirmation_mailer.rb#L40-L45): as the `block` param's sorbet type does not include the type of the param, sorbet is incorrectly typing the param `untyped`.

[Looks like the type of this param is ActionMailer::Collector](https://github.com/rails/rails/blob/6b93fff8af32ef5e91f4ec3cfffb081d0553faf0/actionmailer/lib/action_mailer/base.rb#L985-L986) so I've updated the annotation type accordingly. 

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [X] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: actionmailer
* Gem version: 7.1.2
* Gem source: [actionmailer/lib/action_mailer/base.rb](https://github.com/rails/rails/blob/main/actionmailer/lib/action_mailer/base.rb#L869)
* Gem API doc: https://api.rubyonrails.org/v7.1.2/classes/ActionMailer/Base.html#method-i-mail
* Tapioca version: 0.12.0
* Sorbet version: 0.5.11284
