### PR TITLE
Fix GraphQL `HasFields#field` RBI

### DIFF
--- a/rbi/annotations/graphql.rbi
+++ b/rbi/annotations/graphql.rbi
@@ -38,7 +38,7 @@ module GraphQL::Schema::Member::HasFields
     params(
       args: T.untyped,
       kwargs: T.untyped,
-      block: T.nilable(T.proc.bind(GraphQL::Schema::Field).void)
+      block: T.nilable(T.proc.params(field: GraphQL::Schema::Field).bind(GraphQL::Schema::Field).void)
     ).returns(T.untyped)
   end
   def field(*args, **kwargs, &block); end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] ~Add RBI for a new gem~
- [x] Modify RBI for an existing gem
- [ ] ~Other: <!-- Provide additional information -->~

### Changes

[`GraphQL::Schema::HasFields#field`](https://github.com/rmosolgo/graphql-ruby/blob/ef00294027db2fc3bb167d259d5168dcf1af2146/lib/graphql/schema/field.rb) [supports an optional argument](https://github.com/rmosolgo/graphql-ruby/blob/ef00294027db2fc3bb167d259d5168dcf1af2146/lib/graphql/schema/field.rb#L343-L349), in a way that makes both of these legal:

```ruby
# From https://graphql-ruby.org/fields/arguments
field :search_posts, [PostType], null: false do
  # `argument` called on `self`, depends on the `.bind(GraphQL::Schema::Field)`
  argument :category, String
end

field :search_posts, [PostType], null: false do |field|
  # `argument` called on `field`, depends on the `.params(field: GraphQL::Schema::Field)`
  field.argument :category, String
end
```

* Gem name: `graphql`
* Gem version: any
* Gem source: https://github.com/rmosolgo/graphql-ruby/blob/ef00294027db2fc3bb167d259d5168dcf1af2146/lib/graphql/schema/field.rb#L343-L349
* Gem API doc: https://graphql-ruby.org/api-doc/2.3.0/GraphQL/Schema/Member/HasFields.html#field-instance_method
* Tapioca version: `0.13.1`
* Sorbet version: `Sorbet typechecker 0.5.11305 git 68535070f161acbb6a5668ecf95114fca3460918 debug_symbols=true clean=1`
