### PR TITLE
Update annotation for graphql.rbi parse

### DIFF
--- a/rbi/annotations/graphql.rbi
+++ b/rbi/annotations/graphql.rbi
@@ -2,8 +2,8 @@
 
 module GraphQL
   class << self
-    sig { params(graphql_string: String, trace: T.untyped, filename: T.untyped).returns(GraphQL::Language::Nodes::Document) }
-    def parse(graphql_string, trace: T.unsafe(nil), filename: T.unsafe(nil)); end
+    sig { params(graphql_string: String, trace: T.untyped, filename: T.untyped, max_tokens: T.untyped).returns(GraphQL::Language::Nodes::Document) }
+    def parse(graphql_string, trace: T.unsafe(nil), filename: T.unsafe(nil), max_tokens: T.unsafe(nil)); end
   end
 end
 


### PR DESCRIPTION
Added new annotations for last graphql version:https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql.rb

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: graphql
* Gem version: 2.3.2
* Gem source: https://github.com/rmosolgo/graphql-ruby/blob/v2.3.2/lib/graphql.rb#L45
* Gem API doc: https://graphql-ruby.org/api-doc/2.3.2/
* Tapioca version: 0.14
* Sorbet version: 0.5.11268
