### PR TITLE
Add missing controller to Devise RBI

### DIFF
--- a/rbi/annotations/devise.rbi
+++ b/rbi/annotations/devise.rbi
@@ -145,3 +145,26 @@ class Devise::UnlocksController < DeviseController
   sig { params(resource: T.untyped).returns(String) }
   def after_unlock_path_for(resource); end
 end
+
+# @shim: Devise controllers are loaded by rails
+class Devise::OmniauthCallbacksController < DeviseController
+  # GET|POST /resource/auth/provider
+  sig { returns(T.untyped) }
+  def passthru; end
+
+  # GET|POST /resource/auth/provider/callback
+  sig { returns(T.untyped) }
+  def failure; end
+
+  sig { returns(String) }
+  def failed_strategy; end
+
+  sig { returns(String) }
+  def failure_message; end
+
+  sig { params(scope: String).returns(String) }
+  def after_omniauth_failure_path_for(scope); end
+
+  sig { returns(String) }
+  def translation_scope; end
+end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [X] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: [Devise](https://github.com/heartcombo/devise)
* Gem version: 4.9.4
* Gem source: https://github.com/heartcombo/devise/blob/v4.9.4/app/controllers/devise/omniauth_callbacks_controller.rb
* Gem API doc: https://rubydoc.info/github/heartcombo/devise/Devise/OmniauthCallbacksController
* Tapioca version: 0.14.3
* Sorbet version: 0.5.11414

closes https://github.com/Shopify/rbi-central/issues/248