### PR TITLE
Use base repo name in message

### DIFF
--- a/.github/workflows/team_ruby_dx.yml
+++ b/.github/workflows/team_ruby_dx.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           PULL_URL: ${{ github.event.pull_request.html_url }}
           PULL_NUMBER: ${{ github.event.pull_request.number }}
-          PULL_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PULL_REPO: ${{ github.repository }}
           PULL_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           curl -X POST -H 'Content-type: application/json' --fail ${{ secrets.SLACK_WEBHOOK_URL }} --data \


### PR DESCRIPTION
Current message includes forked repo names and `github.com/external-user/rbi-central/pulls/1` doesn't redirect to PR on `rbi-central`.