### PR TITLE
fix(graphql): execute can return a Result object

### DIFF
--- a/rbi/annotations/graphql.rbi
+++ b/rbi/annotations/graphql.rbi
@@ -13,7 +13,7 @@ end
 
 class GraphQL::Schema
   class << self
-    sig { params(query_str: String, kwargs: T.untyped).returns(T::Hash[String, T.untyped]) }
+    sig { params(query_str: String, kwargs: T.untyped).returns(GraphQL::Query::Result) }
     def execute(query_str = T.unsafe(nil), **kwargs); end
   end
 end


### PR DESCRIPTION
### Type of Change

Fixes https://github.com/Shopify/rbi-central/issues/250

See also https://github.com/rmosolgo/graphql-ruby/issues/4982 and https://github.com/rmosolgo/graphql-ruby/pull/4984

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: graphql
* Gem version: latest
* Gem source: linked above
* Gem API doc: https://graphql-ruby.org/api-doc/2.3.0/GraphQL/Query/Result and https://github.com/rmosolgo/graphql-ruby/pull/4984
* Tapioca version: latest
* Sorbet version: latest