### PR TITLE
Return TimeWithZone from Time.current

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -267,9 +267,6 @@ class Time
 
   sig { returns(ActiveSupport::TimeZone) }
   def self.zone; end
-
-  sig { returns(T.any(ActiveSupport::TimeWithZone, ::Time)) }
-  def self.current; end
 end
 
 class Symbol


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: `activesupport`
* Gem version: <!-- Add the version of the gem you have a problem with here (if applicable) -->
* Gem source: 
* Gem API doc: [Time.current](https://api.rubyonrails.org/classes/Time.html#method-c-current) and [Time.zone](https://api.rubyonrails.org/classes/Time.html#method-c-zone)
* Tapioca version: <!-- Add the version of Tapioca you use -->
* Sorbet version: <!-- Add the version of Sorbet you use -->

### Description

Fixes https://github.com/Shopify/rbi-central/issues/261

Although the documentation does indicate that [`Time.current` should be able to return a `Time` object](https://api.rubyonrails.org/classes/Time.html#method-c-current) this [is unlikely to happen in a Rails application](https://github.com/Shopify/rbi-central/issues/261#issuecomment-2218566655). This PR is to mitigate the need of extra code from consumers that might want to assign the return of `Time.current` to a `TimeWithZone`.


Ideally we should make the `TimeWithZone` to inherit from `Time`, since it hacks its way to be like a `Time`, but this was [failing CI](https://github.com/Shopify/rbi-central/actions/runs/9938221887/job/27450216515) and it can be in a different PR.