### PR TITLE
Add missing payment_method_details to stripe.rbi

### DIFF
--- a/rbi/annotations/stripe.rbi
+++ b/rbi/annotations/stripe.rbi
@@ -212,6 +212,10 @@ class Stripe::Charge < Stripe::APIResource
   sig { returns(T.nilable(T.any(String, Stripe::Customer))) }
   def customer; end
 
+  # @method_missing: from StripeObject
+  sig { returns(T.nilable(Stripe::PaymentMethod)) }
+  def payment_method_details; end
+
   sig { params(id: T.any(String, T::Hash[Symbol, T.untyped]), opts: T.nilable(T::Hash[T.untyped, T.untyped])).returns(Stripe::Charge) }
   def self.retrieve(id, opts = {}); end
 end


### PR DESCRIPTION

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

Stripe Charges respond to payment_method_details which returns a StripeObject that responds to different methods depending on the type returned https://docs.stripe.com/api/charges/object#charge_object-payment_method_details

* Gem name: stripe
* Gem version: 8.7.0
* Gem source: https://github.com/stripe/stripe-ruby/tree/v8.7.0
* Gem API doc: https://docs.stripe.com/api/charges/object#charge_object-payment_method_details
* Tapioca version: 0.12.0
* Sorbet version: 0.5.11284
