### PR TITLE
Add Phonelib area code

### DIFF
--- a/rbi/annotations/phonelib.rbi
+++ b/rbi/annotations/phonelib.rbi
@@ -30,6 +30,9 @@ module Phonelib
   end
 
   module PhoneFormatter
+    sig { returns(T.nilable(String)) }
+    def area_code; end
+
     sig { params(formatted: T::Boolean).returns(String) }
     def national(formatted = true); end
 


### PR DESCRIPTION
This bit me when trying to use the area code with `delete_prefix`, which doesn't accept `nil`.

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: Phonelib
* Gem version: 0.9.1
* Gem source: https://github.com/daddyz/phonelib/blob/466a328ec14d25e95542dc7eb70a358e051620bb/lib/phonelib/phone_formatter.rb#L96-L108
