### PR TITLE
Add annotation for ActiveRecord::Relation#each

### DIFF
--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -196,6 +196,12 @@ class ActiveRecord::Base
 end
 
 class ActiveRecord::Relation
+  Elem = type_member(:out) { { fixed: T.untyped } }
+
   sig { returns(T::Boolean) }
   def blank?; end
+
+  sig { abstract.params(blk: T.proc.params(arg0: Elem).returns(BasicObject)).returns(T.untyped) }
+  sig { abstract.returns(T::Enumerator[Elem]) }
+  def each(&blk); end
 end


### PR DESCRIPTION
The generic type_member was necessary to prevent the following error:
> type_member type Enumerable::Elem used outside of the class definition https://srb.help/5072


Using anything other than `{ { fixed: T.untyped } }` would cause breakages that would need to be addressed separately.

For example: Using `{ { upper: ActiveRecord::Base } }` doesn't work as the rails `:has_and_belongs_to_many` leads to Tapioca rbi output that don't inherit from anything, even though the classes should inherit from ActiveRecord::Base. Additionally, there may be user code that references ActiveRecord::Relation, which would break unless it was changed to something like `ActiveRecord::Relation[ActiveRecord::Base]` (and the class would need to be patched to extend T::Generic, which seems unacceptable). 


### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: 

### Changes

* Gem name: activerecord
* Gem version: 7.1.3.4
* Tapioca version: 0.16.2
* Sorbet version: 0.5.11602
