### PR TITLE
fully qualify DEFAULT_JITTER constant

### DIFF
--- a/rbi/annotations/activejob.rbi
+++ b/rbi/annotations/activejob.rbi
@@ -72,7 +72,7 @@ class ActiveJob::Base
       block: T.nilable(T.proc.params(job: T.attached_class, error: T.untyped).void)
     ).void
   end
-  def self.retry_on(*exceptions, wait: 3.seconds, attempts: 5, queue: nil, priority: nil, jitter: JITTER_DEFAULT, &block); end
+  def self.retry_on(*exceptions, wait: 3.seconds, attempts: 5, queue: nil, priority: nil, jitter: ActiveJob::Exceptions::JITTER_DEFAULT, &block); end
 
   sig { params(part_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.bind(T.attached_class).returns(T.untyped))).void }
   def self.queue_as(part_name = nil, &block); end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

When I was initializing a new repo, a `todo.rb` file was being created for this constant, looks like it needs to be fully qualified to not cause an issue.

<!-- Include the following information with your PR -->

* Gem name: ActiveJob
* Gem version: activejob 8.0.0.rc1
* Gem source: https://github.com/rails/rails/blob/ac98964910369dd9821316a68f5477bd0d8e4ced/activejob/lib/active_job/exceptions.rb#L158
* Gem API doc: https://edgeapi.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html
* Tapioca version: v0.16.3
* Sorbet version: 0.5.9204
