### PR TITLE
Support versioned RBI annotations in CLI check

### DIFF
--- a/gem/lib/rbi-central.rb
+++ b/gem/lib/rbi-central.rb
@@ -75,9 +75,6 @@ module RBICentral
 
     Sorbet/EnforceSignatures:
       Enabled: true
-
-    Lint/DuplicateMethods:
-      Enabled: false
   YML
 
   class Error < StandardError; end

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -456,6 +456,21 @@ class String
 end
 
 class ActiveSupport::ErrorReporter
+  # @version ~> 7.0.0
+  sig do
+    type_parameters(:Block, :Fallback)
+      .params(
+        error_class: T.class_of(Exception),
+        severity: T.nilable(Symbol),
+        context: T.nilable(T::Hash[Symbol, T.untyped]),
+        fallback: T.nilable(T.proc.returns(T.type_parameter(:Fallback))),
+        blk: T.proc.returns(T.type_parameter(:Block)),
+      )
+      .returns(T.any(T.type_parameter(:Block), T.type_parameter(:Fallback)))
+  end
+  def handle(error_class, severity: T.unsafe(nil), context: T.unsafe(nil), fallback: T.unsafe(nil), &blk); end
+
+  # @version >= 7.1.0.beta1
   sig do
     type_parameters(:Block, :Fallback)
       .params(
@@ -470,6 +485,20 @@ class ActiveSupport::ErrorReporter
   end
   def handle(*error_classes, severity: T.unsafe(nil), context: T.unsafe(nil), fallback: T.unsafe(nil), source: T.unsafe(nil), &blk); end
 
+  # @version ~> 7.0.0
+  sig do
+    type_parameters(:Block)
+      .params(
+        error_class: T.class_of(Exception),
+        severity: T.nilable(Symbol),
+        context: T.nilable(T::Hash[Symbol, T.untyped]),
+        blk: T.proc.returns(T.type_parameter(:Block)),
+      )
+      .returns(T.type_parameter(:Block))
+  end
+  def record(error_class, severity: T.unsafe(nil), context: T.unsafe(nil), &blk); end
+
+  # @version >= 7.1.0.beta1
   sig do
     type_parameters(:Block)
       .params(
@@ -483,6 +512,18 @@ class ActiveSupport::ErrorReporter
   end
   def record(*error_classes, severity: T.unsafe(nil), context: T.unsafe(nil), source: T.unsafe(nil), &blk); end
 
+  # @version ~> 7.0.0
+  sig do
+    params(
+      error: Exception,
+      handled: T::Boolean,
+      severity: T.nilable(Symbol),
+      context: T::Hash[Symbol, T.untyped],
+    ).void
+  end
+  def report(error, handled:, severity: T.unsafe(nil), context: T.unsafe(nil)); end
+
+  # @version >= 7.1.0.beta1
   sig do
     params(
       error: Exception,


### PR DESCRIPTION
... and backfill the 7.0 signatures

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: <!-- Add the name of the gem you have a problem with here -->
* Gem version: <!-- Add the version of the gem you have a problem with here (if applicable) -->
* Gem source: <!-- Link relevant source code from the gem for the problem you have -->
* Gem API doc: <!-- Link relevant API doc from the gem for the problem you have -->
* Tapioca version: <!-- Add the version of Tapioca you use -->
* Sorbet version: <!-- Add the version of Sorbet you use -->
