### PR TITLE
Add annotation for `after` for Minitest::HooksSpec

### DIFF
--- a/index.json
+++ b/index.json
@@ -79,6 +79,14 @@
   "lhm": {},
   "lhm-shopify": {},
   "minitest": {},
+  "minitest-hooks": {
+    "dependencies": [
+      "minitest"
+    ],
+    "requires": [
+      "minitest/hooks"
+    ]
+  },
   "mocha": {
     "requires": [
       "mocha/api"

--- a/rbi/annotations/minitest-hooks.rbi
+++ b/rbi/annotations/minitest-hooks.rbi
@@ -1,0 +1,9 @@
+# typed: true
+
+class Minitest::HooksSpec
+  sig { params(type: T.nilable(Symbol), block: T.proc.bind(T.attached_class).void).void }
+  def self.before(type = nil, &block); end
+
+  sig { params(type: T.nilable(Symbol), block: T.proc.bind(T.attached_class).void).void }
+  def self.after(type = nil, &block); end
+end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

(this is from the minitest-hooks gem, not minitest itself)

https://github.com/jeremyevans/minitest-hooks/blob/332e0bc69c811ae8dbc4c1c9d7c744da786585d6/lib/minitest/hooks/test.rb#L125-L135

