### PR TITLE
Version `GraphQL.parse` annotations

### DIFF
--- a/rbi/annotations/graphql.rbi
+++ b/rbi/annotations/graphql.rbi
@@ -2,6 +2,10 @@
 
 module GraphQL
   class << self
+    # @version < 2.3.1
+    sig { params(graphql_string: String, trace: T.untyped, filename: T.untyped).returns(GraphQL::Language::Nodes::Document) }
+    def parse(graphql_string, trace: T.unsafe(nil), filename: T.unsafe(nil)); end
+    # @version >= 2.3.1
     sig { params(graphql_string: String, trace: T.untyped, filename: T.untyped, max_tokens: T.untyped).returns(GraphQL::Language::Nodes::Document) }
     def parse(graphql_string, trace: T.unsafe(nil), filename: T.unsafe(nil), max_tokens: T.unsafe(nil)); end
   end


### PR DESCRIPTION
### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

The `max_tokens` parameter was added in v2.3.1: https://github.com/rmosolgo/graphql-ruby/blob/v2.4.8/CHANGELOG.md#231-22-apr-2024

* Gem name: `graphql`
* Gem version: `2.2.16`
* Gem source: https://github.com/rmosolgo/graphql-ruby/blob/v2.2.16/lib/graphql/language/parser.rb#L15
* Gem API doc: N/A
* Tapioca version: `0.16.8`
* Sorbet version: `0.5.11770`
