### PR TITLE
Improve typing of `Stripe::ApiResource#metadata`

### DIFF
--- a/rbi/annotations/stripe.rbi
+++ b/rbi/annotations/stripe.rbi
@@ -12,7 +12,7 @@ class Stripe::APIResource < Stripe::StripeObject
 
   # not all objects, at all times have metadata (deleted customers for instance)
   # @method_missing: from StripeObject
-  sig { returns(T::Hash[T.any(String, Symbol), T.untyped]) }
+  sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def metadata; end
 
   # @method_missing: from StripeObject


### PR DESCRIPTION
### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other:

### Changes

Per [the docs](https://docs.stripe.com/metadata), metadata values are always strings (there is no nesting). I opted to not change the signature of `#metadata=` because you can technically pass in non-strings to the method and either the values will be stringified (e.g. `1` becomes `"1"`) or the keys ignored (e.g. a key with a `nil` value).

Technically, you could have junk in there until you refresh the data, but I'm not sure supporting that is desirable?

```ruby
charge = Stripe::Charge.retrieve(...)

charge.metadata = { int: 1, true: true, false: false, nil: nil, obj: User.first, nested: {outer: {inner: [1, 2, 3]}} }
charge.metadata
=> {:int=>1,
 :true=>true,
 :false=>false,
 :nil=>nil,
 :obj=>
  #<User:0x0000000110435f10 ...>,
 :nested=>{:outer=>{:inner=>[1, 2, 3]}}}

Stripe::Charge.update(charge.id)
charge.metadata
=> #<Stripe::StripeObject:0x1b490> JSON: {
  "int": 1,
  "true": true,
  "false": false,
  "nil": null,
  "obj": "#<User:0x0000000121a34ec8>",
  "nested": {"outer":{"inner":[1,2,3]}}
}

charge.refresh.metadata
=> #<Stripe::StripeObject:0x1b4b8> JSON: {
  "false": "false",
  "int": "1",
  "obj": "#<User:0x00000001198346d0>",
  "true": "true"
}
```

* Gem name: `stripe`
* Gem version: all
* Gem source: https://github.com/stripe/stripe-ruby/
* Gem API doc: https://docs.stripe.com/metadata
* Tapioca version: latest
* Sorbet version: latest
