### PR TITLE
Add `latest_charge` method to Stripe PaymentIntent object

### DIFF
--- a/rbi/annotations/stripe.rbi
+++ b/rbi/annotations/stripe.rbi
@@ -601,6 +601,10 @@ class Stripe::PaymentIntent < Stripe::APIResource
   def charges; end
 
   # @method_missing: from StripeObject
+  sig { returns(T.nilable(Stripe::Charge)) }
+  def latest_charge; end
+
+  # @method_missing: from StripeObject
   sig { returns(Stripe::ListObject) }
   def line_items; end
 


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflects your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Summary

This PR updates the RBI for the `stripe` gem to add the `latest_charge` method to the `PaymentIntent` object. Starting with Stripe API version `2022-11-15`, the `charges` attribute was removed from `PaymentIntent`. The recommended replacement is the `latest_charge` attribute. I leave the `charges` method for the clients that are still using Stripe API with the version older than `2022-11-15`.

For more details, see the Stripe changelog: https://docs.stripe.com/changelog/2022-11-15/removes-charges-attribute-paymentintent

### Details

- **Gem name:** `stripe`
- **Gem version:** `13.2.0`
- **Gem source:** https://github.com/stripe/stripe-ruby (It's coming from `method_missing` on `StripeObject` [code](https://github.com/stripe/stripe-ruby/blob/v13.2.0/lib/stripe/stripe_object.rb#L377) )
- **Tapioca version:** `0.16.11`
- **Sorbet version:** <!-- Add the Sorbet version you use -->
- **Relevant API docs:** <!-- Add a link to the relevant Stripe API docs, if available -->