### PR TITLE
`ActionDispatch::Http::Parameters#params` returns a `Hash`

### DIFF
--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -225,11 +225,11 @@ module ActionController::StrongParameters
 end
 
 module ActionDispatch::Http::Parameters
-  sig { returns(ActionController::Parameters) }
+  sig { returns(T::Hash[Symbol, String]) }
   def parameters; end
 
   # params is an alias of parameters
-  sig { returns(ActionController::Parameters) }
+  sig { returns(T::Hash[Symbol, String]) }
   def params; end
 end
 

--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -225,11 +225,11 @@ module ActionController::StrongParameters
 end
 
 module ActionDispatch::Http::Parameters
-  sig { returns(T::Hash[Symbol, String]) }
+  sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def parameters; end
 
   # params is an alias of parameters
-  sig { returns(T::Hash[Symbol, String]) }
+  sig { returns(T::Hash[T.any(String, Symbol), String]) }
   def params; end
 end
 


### PR DESCRIPTION
See https://api.rubyonrails.org/classes/ActionDispatch/Http/Parameters.html#method-i-parameters.

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: actionpack
* Gem version: 7, 8
* Gem source: https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/actionpack/lib/action_dispatch/http/parameters.rb#L52
* Gem API doc: https://api.rubyonrails.org/classes/ActionDispatch/Http/Parameters.html#method-i-parameters
* Tapioca version: 0.16.11
* Sorbet version: 0.5.12043 git 74bda9a917879ed3e416581e34033181e5697e2f
