### PR TITLE
Add signature for ActiveSupport's `assert_nothing_raised`

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -552,3 +552,10 @@ class ActiveSupport::ErrorReporter
   end
   def unexpected(error, severity: T.unsafe(nil), context: T.unsafe(nil), source: T.unsafe(nil)); end
 end
+
+module ActiveSupport::Testing::Assertions
+  sig do
+    type_parameters(:Block).params(block: T.proc.returns(T.type_parameter(:Block))).returns(T.type_parameter(:Block))
+  end
+  def assert_nothing_raised(&block); end
+end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: Rails / ActiveSupport<!-- Add the name of the gem you have a problem with here -->
* Gem version: <!-- Add the version of the gem you have a problem with here (if applicable) -->
* Gem source: [link](https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/activesupport/lib/active_support/testing/assertions.rb#L48)
* Gem API doc: [link](https://api.rubyonrails.org/classes/ActiveSupport/Testing/Assertions.html#method-i-assert_nothing_raised)
* Tapioca version: <!-- Add the version of Tapioca you use -->
* Sorbet version: <!-- Add the version of Sorbet you use -->
