### PR TITLE
Add signature for `ActiveRecord::Core#==`

### DIFF
--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -205,3 +205,8 @@ class ActiveRecord::Relation
   sig { abstract.returns(T::Enumerator[Elem]) }
   def each(&blk); end
 end
+
+module ActiveRecord::Core
+  sig { params(comparison_object: T.anything).returns(T::Boolean) }
+  def ==(comparison_object); end
+end


### PR DESCRIPTION
### Type of Change

- [ ] Add RBI for a new gem
- [X] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

* Gem name: activerecord
* Gem version: 8.0.2.1
* Gem source: https://github.com/rails/rails/blob/v8.0.2.1/activerecord/lib/active_record/core.rb#L622-L636
* Gem API doc: https://api.rubyonrails.org/classes/ActiveRecord/Core.html#method-i-3D-3D
* Tapioca version: v0.17.7
* Sorbet version: 0.5.12414

This signature helps when you need to chain a comparison between models with some other check.

A silly example:

```ruby
sig { returns(T::Boolean) }
def foo?
  User.first! == User.last! && true
end
```

Without a signature for the `==` operator, Sorbet raises the following error:

> Expected `T::Boolean` but found `T.nilable(T::Boolean)` for method result type[7005](https://srb.help/7005)
