### PR TITLE
update signature | `Money#nonzero?` returns nil or BigDecimal

### DIFF
--- a/rbi/annotations/shopify-money.rbi
+++ b/rbi/annotations/shopify-money.rbi
@@ -21,7 +21,7 @@ class Money
   def zero?(*args, **_arg1, &block); end
 
   # @method_missing: delegated to BigDecimal
-  sig { params(args: T.untyped, _arg1: T.untyped, block: T.nilable(T.proc.void)).returns(T::Boolean) }
+  sig { params(args: T.untyped, _arg1: T.untyped, block: T.nilable(T.proc.void)).returns(T.nilable(BigDecimal)) }
   def nonzero?(*args, **_arg1, &block); end
 
   # @method_missing: delegated to BigDecimal


### PR DESCRIPTION
Updates the signature for `Money#nonzero?` to return `T.nilable(BigDecimal)` instead of `T::Boolean`. Money delegates `#nonzero?` to the underlying value, stored as a `BigDecimal` which returns either `nil` or `self`.

### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

* Gem name: shopify-money, bigdecimal
* Gem source:
  * https://github.com/Shopify/money/blob/bb637314aa797a8017cfd5e7990fcd8d751a62a9/lib/money/money.rb#L139
  * https://github.com/Shopify/money/blob/bb637314aa797a8017cfd5e7990fcd8d751a62a9/lib/money/money.rb#L14
  * https://github.com/ruby/bigdecimal/blob/d93b542015d03b4b20565f59830b20c4d45bf87b/ext/bigdecimal/bigdecimal.c#L1460-L1466
* Gem API doc: https://ruby-doc.org/3.4/gems/bigdecimal/BigDecimal.html#method-i-nonzero-3F
* Tapioca version: 0.16.11
* Sorbet version: 0.5.12358

```
irb(main):002> Money.new(0, 'USD').nonzero?.class
=> NilClass
irb(main):003> Money.new(1, 'USD').nonzero?.class
=> BigDecimal
```


