### PR TITLE
Add annotations for discard gem callbacks

### DIFF
--- a/index.json
+++ b/index.json
@@ -51,6 +51,7 @@
   "configs": {},
   "delayed_job": {},
   "devise": {},
+  "discard": {},
   "elasticsearch-dsl": {
     "requires": [
       "elasticsearch/dsl"

--- a/rbi/annotations/discard.rbi
+++ b/rbi/annotations/discard.rbi
@@ -1,0 +1,27 @@
+# typed: true
+
+module Discard::Model::ClassMethods
+  # @shim: defined dynamically via `define_model_callbacks :discard`
+  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def before_discard(*args, &block); end
+
+  # @shim: defined dynamically via `define_model_callbacks :discard`
+  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def around_discard(*args, &block); end
+
+  # @shim: defined dynamically via `define_model_callbacks :discard`
+  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def after_discard(*args, &block); end
+
+  # @shim: defined dynamically via `define_model_callbacks :undiscard`
+  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def before_undiscard(*args, &block); end
+
+  # @shim: defined dynamically via `define_model_callbacks :undiscard`
+  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def around_undiscard(*args, &block); end
+
+  # @shim: defined dynamically via `define_model_callbacks :undiscard`
+  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def after_undiscard(*args, &block); end
+end

--- a/rbi/annotations/discard.rbi
+++ b/rbi/annotations/discard.rbi
@@ -2,26 +2,26 @@
 
 module Discard::Model::ClassMethods
   # @shim: defined dynamically via `define_model_callbacks :discard`
-  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
-  def before_discard(*args, &block); end
+  sig { params(args: T.untyped, options: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def before_discard(*args, **options, &block); end
 
   # @shim: defined dynamically via `define_model_callbacks :discard`
-  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
-  def around_discard(*args, &block); end
+  sig { params(args: T.untyped, options: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def around_discard(*args, **options, &block); end
 
   # @shim: defined dynamically via `define_model_callbacks :discard`
-  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
-  def after_discard(*args, &block); end
+  sig { params(args: T.untyped, options: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def after_discard(*args, **options, &block); end
 
   # @shim: defined dynamically via `define_model_callbacks :undiscard`
-  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
-  def before_undiscard(*args, &block); end
+  sig { params(args: T.untyped, options: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def before_undiscard(*args, **options, &block); end
 
   # @shim: defined dynamically via `define_model_callbacks :undiscard`
-  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
-  def around_undiscard(*args, &block); end
+  sig { params(args: T.untyped, options: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def around_undiscard(*args, **options, &block); end
 
   # @shim: defined dynamically via `define_model_callbacks :undiscard`
-  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
-  def after_undiscard(*args, &block); end
+  sig { params(args: T.untyped, options: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def after_undiscard(*args, **options, &block); end
 end


### PR DESCRIPTION
### Description

Adds annotations for callback methods defined dynamically by `define_model_callbacks` in `Discard::Model`.

When a model includes `Discard::Model`, the following class methods are defined at runtime via `define_model_callbacks :discard` and `define_model_callbacks :undiscard`:

- `before_discard`, `around_discard`, `after_discard`
- `before_undiscard`, `around_undiscard`, `after_undiscard`

These cannot be captured by `tapioca gem` because they are generated dynamically inside the `included` block, so they are annotated with `@shim`.

---

### Type of Change

<!-- Select the option that best reflect your changes -->

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: discard
* Gem version: 1.4.0
* Gem source: https://github.com/jhawthorn/discard/blob/master/lib/discard/model.rb#L21-L22
* Gem API doc: https://github.com/jhawthorn/discard#callbacks
* Tapioca version: 0.17.10
* Sorbet version: 0.6.12913

---

Thank you for taking the time to review this PR!