### PR TITLE
Add signatures for Hash and ActiveSupport::HashWithIndifferentAccess

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -52,6 +52,7 @@ class ActiveSupport::HashWithIndifferentAccess < Hash
   end
   def deep_merge!(other_hash, &block); end
 
+  # @version >= 7.2
   sig { params(other: T.untyped).returns(T::Boolean) }
   def deep_merge?(other); end
 end
@@ -124,6 +125,9 @@ class Hash
   sig { returns(T.self_type) }
   def compact_blank; end
 
+  sig { returns(ActiveSupport::HashWithIndifferentAccess) }
+  def with_indifferent_access; end
+
   sig do
     type_parameters(:K2, :V2, :ConflictRes).params(
       other_hash: T::Hash[T.type_parameter(:K2), T.type_parameter(:V2)],
@@ -152,6 +156,7 @@ class Hash
   end
   def deep_merge!(other_hash, &block); end
 
+  # @version >= 7.2
   sig { params(other: T.untyped).returns(T::Boolean) }
   def deep_merge?(other); end
 end

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -36,7 +36,7 @@ class ActiveSupport::HashWithIndifferentAccess < Hash
       block: T.nilable(
         T.proc.params(
           key: String,
-          old_val: V,
+          old_val: T.untyped,
           new_val: T.type_parameter(:V2),
         ).returns(T.type_parameter(:ConflictRes))
       ),
@@ -50,7 +50,7 @@ class ActiveSupport::HashWithIndifferentAccess < Hash
       block: T.nilable(
         T.proc.params(
           key: String,
-          old_val: V,
+          old_val: T.untyped,
           new_val: T.type_parameter(:V2),
         ).returns(T.type_parameter(:ConflictRes))
       ),
@@ -144,7 +144,7 @@ class Hash
           new_val: T.type_parameter(:V2),
         ).returns(T.type_parameter(:ConflictRes))
       ),
-    ).returns(T::Hash[T.any(K, T.type_parameter(:K2)), T.any(V, T.type_parameter(:ConflictRes))])
+    ).returns(T::Hash[T.any(K, T.type_parameter(:K2)), T.any(V, T.type_parameter(:V2), T.type_parameter(:ConflictRes))])
   end
   def deep_merge(other_hash, &block); end
 
@@ -158,7 +158,7 @@ class Hash
           new_val: T.type_parameter(:V2),
         ).returns(T.type_parameter(:ConflictRes))
       ),
-    ).returns(T::Hash[T.any(K, T.type_parameter(:K2)), T.any(V, T.type_parameter(:ConflictRes))])
+    ).returns(T::Hash[T.any(K, T.type_parameter(:K2)), T.any(V, T.type_parameter(:V2), T.type_parameter(:ConflictRes))])
   end
   def deep_merge!(other_hash, &block); end
 

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -21,8 +21,6 @@ class ActiveSupport::EnvironmentInquirer
 end
 
 class ActiveSupport::HashWithIndifferentAccess < Hash
-  extend T::Generic
-
   K = type_member { {fixed: T.any(String, Symbol)} }
   V = type_member { {fixed: T.untyped} }
   Elem = type_member { {fixed: T.untyped} }

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -21,6 +21,12 @@ class ActiveSupport::EnvironmentInquirer
 end
 
 class ActiveSupport::HashWithIndifferentAccess < Hash
+  extend T::Generic
+
+  K = type_member {{fixed: T.any(String, Symbol)}}
+  V = type_member {{fixed: T.untyped}}
+  Elem = type_member {{fixed: T.untyped}}
+
   sig { returns(ActiveSupport::HashWithIndifferentAccess) }
   def with_indifferent_access; end
 

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -20,6 +20,42 @@ class ActiveSupport::EnvironmentInquirer
   def local?; end
 end
 
+class ActiveSupport::HashWithIndifferentAccess < Hash
+  sig { returns(ActiveSupport::HashWithIndifferentAccess) }
+  def with_indifferent_access; end
+
+  sig do
+    type_parameters(:V2, :ConflictRes).params(
+      other_hash: T::Hash[T.untyped, T.type_parameter(:V2)],
+      block: T.nilable(
+        T.proc.params(
+          key: String,
+          old_val: V,
+          new_val: T.type_parameter(:V2),
+        ).returns(T.type_parameter(:ConflictRes))
+      ),
+    ).returns(ActiveSupport::HashWithIndifferentAccess)
+  end
+  def deep_merge(other_hash, &block); end
+
+  sig do
+    type_parameters(:V2, :ConflictRes).params(
+      other_hash: T::Hash[T.untyped, T.type_parameter(:V2)],
+      block: T.nilable(
+        T.proc.params(
+          key: String,
+          old_val: V,
+          new_val: T.type_parameter(:V2),
+        ).returns(T.type_parameter(:ConflictRes))
+      ),
+    ).returns(ActiveSupport::HashWithIndifferentAccess)
+  end
+  def deep_merge!(other_hash, &block); end
+
+  sig { params(other: T.untyped).returns(T::Boolean) }
+  def deep_merge?(other); end
+end
+
 module ActiveSupport::Testing::SetupAndTeardown::ClassMethods
   sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.untyped).void)).void }
   def setup(*args, &block); end
@@ -87,6 +123,37 @@ class Hash
   # @version >= 6.1.0
   sig { returns(T.self_type) }
   def compact_blank; end
+
+  sig do
+    type_parameters(:K2, :V2, :ConflictRes).params(
+      other_hash: T::Hash[T.type_parameter(:K2), T.type_parameter(:V2)],
+      block: T.nilable(
+        T.proc.params(
+          key: T.any(K, T.type_parameter(:K2)),
+          old_val: V,
+          new_val: T.type_parameter(:V2),
+        ).returns(T.type_parameter(:ConflictRes))
+      ),
+    ).returns(T::Hash[T.any(K, T.type_parameter(:K2)), T.any(V, T.type_parameter(:ConflictRes))])
+  end
+  def deep_merge(other_hash, &block); end
+
+  sig do
+    type_parameters(:K2, :V2, :ConflictRes).params(
+      other_hash: T::Hash[T.type_parameter(:K2), T.type_parameter(:V2)],
+      block: T.nilable(
+        T.proc.params(
+          key: T.any(K, T.type_parameter(:K2)),
+          old_val: V,
+          new_val: T.type_parameter(:V2),
+        ).returns(T.type_parameter(:ConflictRes))
+      ),
+    ).returns(T::Hash[T.any(K, T.type_parameter(:K2)), T.any(V, T.type_parameter(:ConflictRes))])
+  end
+  def deep_merge!(other_hash, &block); end
+
+  sig { params(other: T.untyped).returns(T::Boolean) }
+  def deep_merge?(other); end
 end
 
 class Array

--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -23,9 +23,9 @@ end
 class ActiveSupport::HashWithIndifferentAccess < Hash
   extend T::Generic
 
-  K = type_member {{fixed: T.any(String, Symbol)}}
-  V = type_member {{fixed: T.untyped}}
-  Elem = type_member {{fixed: T.untyped}}
+  K = type_member { {fixed: T.any(String, Symbol)} }
+  V = type_member { {fixed: T.untyped} }
+  Elem = type_member { {fixed: T.untyped} }
 
   sig { returns(ActiveSupport::HashWithIndifferentAccess) }
   def with_indifferent_access; end


### PR DESCRIPTION
Right now when call `#with_indifferent_access` on `Hash` or `ActiveSupport::HashWithIndifferentAccess` result is `T.untyped`.
Correct this behavior to return proper class - `ActiveSupport::HashWithIndifferentAccess`.
Solution is to add sig for `#with_indifferent_access` to return `ActiveSupport::HashWithIndifferentAccess`.


Similar behavior is met for some of instance methods of `ActiveSupport::HashWithIndifferentAccess`.
As example methods provided by `ActiveSupport::DeepMergeable`: `#deep_merge`, `#deep_merge!`, `#deep_merge?`.
Added signatures for them.
For `ActiveSupport::HashWithIndifferentAccess` methods returned result type should be `ActiveSupport::HashWithIndifferentAccess`.

If this would makes sense to do - it may be expanded to other `ActiveSupport::HashWithIndifferentAccess` methods (provide more similar signatures both for `Hash` and `ActiveSupport::HashWithIndifferentAccess` that are provided by `activesupport`)

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: activesupport
* Gem version: 7.0.8.4
* Gem source: https://github.com/rails/rails/tree/v7.0.8.4/activesupport/lib/active_support
* Tapioca version: 0.18.0
* Sorbet version: 0.6.13055
