### PR TITLE
Skip superclass redefinition error for Net::IMAP::Literal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       rubocop-sorbet (>= 0.6.11)
       sorbet-static-and-runtime (>= 0.5.11922)
       spoom (>= 1.2.0)
-      tapioca (>= 0.17.7)
+      tapioca (>= 0.19.1)
       thor (>= 1.2.1)
 
 GEM
@@ -68,14 +68,16 @@ GEM
       lint_roller
       rubocop (>= 1.75.2)
     ruby-progressbar (1.13.0)
-    sorbet (0.6.12913)
-      sorbet-static (= 0.6.12913)
-    sorbet-runtime (0.6.12913)
-    sorbet-static (0.6.12913-universal-darwin)
-    sorbet-static (0.6.12913-x86_64-linux)
-    sorbet-static-and-runtime (0.6.12913)
-      sorbet (= 0.6.12913)
-      sorbet-runtime (= 0.6.12913)
+    rubydex (0.1.0.beta13-arm64-darwin)
+    rubydex (0.1.0.beta13-x86_64-linux)
+    sorbet (0.6.13164)
+      sorbet-static (= 0.6.13164)
+    sorbet-runtime (0.6.13164)
+    sorbet-static (0.6.13164-universal-darwin)
+    sorbet-static (0.6.13164-x86_64-linux)
+    sorbet-static-and-runtime (0.6.13164)
+      sorbet (= 0.6.13164)
+      sorbet-runtime (= 0.6.13164)
     spoom (1.7.11)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
@@ -84,26 +86,23 @@ GEM
       rexml (>= 3.2.6)
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
-    tapioca (0.17.10)
+    tapioca (0.19.1)
       benchmark
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)
       rbi (>= 0.3.7)
       require-hooks (>= 0.2.2)
-      sorbet-static-and-runtime (>= 0.5.11087)
+      rubydex (>= 0.1.0.beta10)
+      sorbet-static-and-runtime (>= 0.6.12698)
       spoom (>= 1.7.9)
       thor (>= 1.2.0)
-      yard-sorbet
+      tsort
     thor (1.5.0)
     tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    yard (0.9.42)
-    yard-sorbet (0.9.0)
-      sorbet-runtime
-      yard
 
 PLATFORMS
   arm64-darwin-21

--- a/gem/Gemfile.lock
+++ b/gem/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       rubocop-sorbet (>= 0.6.11)
       sorbet-static-and-runtime (>= 0.5.11922)
       spoom (>= 1.2.0)
-      tapioca (>= 0.17.7)
+      tapioca (>= 0.19.1)
       thor (>= 1.2.1)
 
 GEM
@@ -102,14 +102,16 @@ GEM
       lint_roller
       rubocop (>= 1.75.2)
     ruby-progressbar (1.13.0)
-    sorbet (0.6.13071)
-      sorbet-static (= 0.6.13071)
-    sorbet-runtime (0.6.13071)
-    sorbet-static (0.6.13071-universal-darwin)
-    sorbet-static (0.6.13071-x86_64-linux)
-    sorbet-static-and-runtime (0.6.13071)
-      sorbet (= 0.6.13071)
-      sorbet-runtime (= 0.6.13071)
+    rubydex (0.1.0.beta13-arm64-darwin)
+    rubydex (0.1.0.beta13-x86_64-linux)
+    sorbet (0.6.13164)
+      sorbet-static (= 0.6.13164)
+    sorbet-runtime (0.6.13164)
+    sorbet-static (0.6.13164-universal-darwin)
+    sorbet-static (0.6.13164-x86_64-linux)
+    sorbet-static-and-runtime (0.6.13164)
+      sorbet (= 0.6.13164)
+      sorbet-runtime (= 0.6.13164)
     spoom (1.7.11)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
@@ -119,32 +121,29 @@ GEM
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
     stringio (3.2.0)
-    tapioca (0.18.0)
+    tapioca (0.19.1)
       benchmark
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)
       rbi (>= 0.3.7)
       require-hooks (>= 0.2.2)
-      sorbet-static-and-runtime (>= 0.5.11087)
+      rubydex (>= 0.1.0.beta10)
+      sorbet-static-and-runtime (>= 0.6.12698)
       spoom (>= 1.7.9)
       thor (>= 1.2.0)
       tsort
-      yard-sorbet
     thor (1.5.0)
     tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    yard (0.9.42)
-    yard-sorbet (0.9.0)
-      sorbet-runtime
-      yard
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/gem/lib/rbi-central/static/context.rb
+++ b/gem/lib/rbi-central/static/context.rb
@@ -67,7 +67,8 @@ module RBICentral
           "--no-error-sections --color=#{@color ? "always" : "never"} " \
           "--ignore vendor/bundle --no-config --no-error-count " \
           "--suppress-payload-superclass-redefinition-for=Reline::ANSI " \
-          "--suppress-payload-superclass-redefinition-for=RDoc::Markup::Heading")
+          "--suppress-payload-superclass-redefinition-for=RDoc::Markup::Heading " \
+          "--suppress-payload-superclass-redefinition-for=Net::IMAP::Literal")
         unless res.status
           errors << Error.new(res.err)
         end

--- a/gem/rbi-central.gemspec
+++ b/gem/rbi-central.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("rubocop-sorbet", ">= 0.6.11")
   spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.11922")
   spec.add_dependency("spoom", ">= 1.2.0")
-  spec.add_dependency("tapioca", ">= 0.17.7")
+  spec.add_dependency("tapioca", ">= 0.19.1")
   spec.add_dependency("thor", ">= 1.2.1")
 
   spec.required_ruby_version = ">= 3.2"


### PR DESCRIPTION
### Type of Change

- [x] Modify RBI for an existing gem
- [x] Update gem dependencies

### Changes

`Net::IMAP::Literal` in net-imap-0.6.4 directly inherits from `Data.define` and type checking with Sorbet payload detects super class redefinition error. This PR adds `--suppress-payload-superclass-redefinition-for=Net::IMAP::Literal` option to ignore the error.

In addition, `tapioca` and `sorbet` are bumped to fix CI:

- `tapioca 0.18.0` calls `has_rest` on `T::Private::Methods::Signature`, which is no longer available in newer `sorbet-runtime` releases. Test fixtures that run `bundle install` resolve against the latest `sorbet-runtime` (currently `0.6.13164`) and crash with `NoMethodError`, breaking `CheckStaticTest`, `RepoTest`, and `CheckTest`.
- Bump `tapioca` to `0.19.1` and raise the gemspec floor to `>= 0.19.1` so consumers (including our test fixtures) cannot resolve back to `0.18.0`.
- Bump the `sorbet*` family from `0.6.13071`/`0.6.12913` to `0.6.13164` so our lockfiles match what fixtures install at runtime.

`tapioca 0.19.x` introduces a transitive dependency on `rubydex (>= 0.1.0.beta10)`, currently a prerelease. Bundler resolves this without `--pre` because no stable version satisfies the constraint.

(Originally split as #392, then folded back here since the IMAP fix can't be verified in CI without the bump.)