### PR TITLE
Add Mock class for Mocha

### DIFF
--- a/rbi/annotations/mocha.rbi
+++ b/rbi/annotations/mocha.rbi
@@ -1,5 +1,32 @@
 # typed: true
 
+class Mocha::Mock
+  sig do
+    params(
+      method_name_or_hash: T.any(Symbol, String, T::Hash[Symbol, T.untyped]),
+      backtrace: T.nilable(T::Array[String])
+    ).returns(Mocha::Expectation)
+  end
+  def expects(method_name_or_hash, backtrace = nil); end
+
+  sig do
+    params(
+      method_name_or_hash: T.any(Symbol, String, T::Hash[Symbol, T.untyped]),
+      backtrace: T.nilable(T::Array[String])
+    ).returns(Mocha::Expectation)
+  end
+  def stubs(method_name_or_hash, backtrace = nil); end
+
+  sig { params(method_names: Symbol).void }
+  def unstub(*method_names); end
+
+  sig { params(responder: Object).returns(T.self_type) }
+  def responds_like(responder); end
+
+  sig { params(responder_class: T::Class[T.untyped]).returns(T.self_type) }
+  def responds_like_instance_of(responder_class); end
+end
+
 module Mocha::API
   sig { params(arguments: T.untyped).returns(Mocha::Mock) }
   def mock(*arguments); end


### PR DESCRIPTION
Mock was being referred to without definition causing an error with sorbet:

sorbet/rbi/annotations/mocha.rbi:8: Unable to resolve constant Mock https://srb.help/5002
     8 |  sig { params(arguments: T.untyped).returns(Mocha::Mock) }

Add the definition of the Mock class to resolve this error as well as make the type more complete.

### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: Mocha
* Gem version: 3.1.0
* Gem source: https://github.com/freerange/mocha/blob/main/lib/mocha/mock.rb
* Gem API doc: https://mocha.jamesmead.org/Mocha/Mock.html
* Tapioca version: 0.18.0
* Sorbet version: 0.6.13096
