### PR TITLE
Add Rails::Railtie.rake_tasks sig

### DIFF
--- a/rbi/annotations/railties.rbi
+++ b/rbi/annotations/railties.rbi
@@ -64,6 +64,11 @@ end
 class Rails::Railtie
   sig { params(block: T.proc.bind(Rails::Railtie).void).void }
   def configure(&block); end
+
+  class << self
+    sig { params(block: T.proc.bind(Rake::DSL).params(app: Rails::Application).void).void }
+    def rake_tasks(&block); end
+  end
 end
 
 class Rails::Railtie::Configuration


### PR DESCRIPTION
## Summary

Adds a sig for `Rails::Railtie.rake_tasks` that binds the block to `Rake::DSL` and types the yielded `app` argument as `Rails::Application`.

In Rails, [`run_tasks_blocks`](https://github.com/rails/rails/blob/main/railties/lib/rails/railtie.rb) executes registered blocks via `instance_exec(app, &block)` after `extend Rake::DSL`, so `self` inside the block legitimately responds to `task`, `namespace`, `desc`, etc.

Without this annotation, idiomatic code like:

```ruby
class MyEngine < ::Rails::Engine
  rake_tasks do |_app|
    task 'db:schema:dump': 'strong_migrations:alphabetize_columns'
  end
end
```

fails type checking under `# typed: true` with:

```
Method `task` does not exist on `T.class_of(MyEngine)` https://srb.help/7003
```

forcing users to fall back to `T.unsafe(self).task(...)` (which disables checking entirely) or to drop the file to `# typed: false`.

This mirrors the existing DSL-binding pattern already used in this file for `Rails::Engine#routes` (binds to `ActionDispatch::Routing::Mapper`), `Rails::Application#configure` (binds to `Rails::Application`), and `Rails::Railtie::Configuration#to_prepare` (binds to `ActiveSupport::Reloader`).

`rake` is already listed in the `requires` for railties in `index.json`, so `Rake::DSL` is available without index changes.

## Test plan

- [x] `bundle exec repo check static` passes
- [x] `bundle exec repo check runtime` passes
- [x] `bundle exec repo check rubocop` passes