### PR TITLE
Add sigs for Active Support error report assertions

### DIFF
--- a/rbi/annotations/activesupport.rbi
+++ b/rbi/annotations/activesupport.rbi
@@ -684,3 +684,17 @@ module ActiveSupport::Testing::Assertions
   end
   def assert_changes(expression, message = T.unsafe(nil), from: T.unsafe(nil), to: T.unsafe(nil), &block); end
 end
+
+module ActiveSupport::Testing::ErrorReporterAssertions
+  # @version >= 7.1.0.rc1
+  sig do
+    params(error_class: T.class_of(Exception), block: T.proc.void).returns(ActiveSupport::Testing::ErrorReporterAssertions::ErrorCollector::Report)
+  end
+  def assert_error_reported(error_class = T.unsafe(nil), &block); end
+
+  # @version >= 8.1.0.beta1
+  sig do
+    params(error_class: T.class_of(Exception), block: T.proc.void).returns(T::Array[ActiveSupport::Testing::ErrorReporterAssertions::ErrorCollector::Report])
+  end
+  def capture_error_reports(error_class = T.unsafe(nil), &block); end
+end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

<!-- Include the following information with your PR -->

* Gem name: Active Support
* Gem source: https://github.com/rails/rails/blob/5de2d28389a50a2e0d669f2d157eb6f89b59103a/activesupport/lib/active_support/testing/error_reporter_assertions.rb#L88
