### PR TITLE
Add ActiveModel/Record attribute methods sigs

### DIFF
--- a/rbi/annotations/activemodel.rbi
+++ b/rbi/annotations/activemodel.rbi
@@ -1,5 +1,35 @@
 # typed: true
 
+module ActiveModel::Attributes
+  sig { returns(T::Array[String]) }
+  def attribute_names; end
+
+  sig { returns(T::Hash[String, T.untyped]) }
+  def attributes; end
+end
+
+module ActiveModel::Attributes::ClassMethods
+  sig { returns(T::Array[String]) }
+  def attribute_names; end
+end
+
+module ActiveModel::Dirty
+  sig { returns(T::Array[String]) }
+  def changed; end
+
+  sig { returns(T::Boolean) }
+  def changed?; end
+
+  sig { returns(T::Hash[String, T.untyped]) }
+  def changed_attributes; end
+
+  sig { returns(T::Hash[String, [T.untyped, T.untyped]]) }
+  def changes; end
+
+  sig { returns(T::Hash[String, [T.untyped, T.untyped]]) }
+  def previous_changes; end
+end
+
 class ActiveModel::Errors
   Elem = type_member { { fixed: ActiveModel::Error } }
 

--- a/rbi/annotations/activerecord.rbi
+++ b/rbi/annotations/activerecord.rbi
@@ -1,5 +1,30 @@
 # typed: true
 
+module ActiveRecord::AttributeMethods::ClassMethods
+  sig { returns(T::Array[String]) }
+  def attribute_names; end
+end
+
+module ActiveRecord::AttributeMethods::Dirty
+  sig { returns(T::Hash[String, T.untyped]) }
+  def attributes_in_database; end
+
+  sig { returns(T::Array[String]) }
+  def changed_attribute_names_to_save; end
+
+  sig { returns(T::Hash[String, [T.untyped, T.untyped]]) }
+  def changes_to_save; end
+
+  sig { returns(T::Boolean) }
+  def has_changes_to_save?; end
+
+  sig { returns(T::Hash[String, [T.untyped, T.untyped]]) }
+  def saved_changes; end
+
+  sig { returns(T::Boolean) }
+  def saved_changes?; end
+end
+
 class ActiveRecord::Schema
   sig { params(info: T::Hash[T.untyped, T.untyped], blk: T.proc.bind(ActiveRecord::Schema).void).void }
   def self.define(info = nil, &blk); end


### PR DESCRIPTION
### Type of Change

<!-- Select the option that best reflect your changes -->

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

I noticed people writing code assuming these methods return symbols instead of strings, so it wasn't giving the results they were expecting. These signatures will now flag that kind of thing, e.g. `app/models/member.rb:139: Expected String but found Symbol(:address_line1) for argument arg0 https://srb.help/7002`

* Gem name: Active Model / Record
* Gem API doc:
  * https://api.rubyonrails.org/classes/ActiveModel/Attributes.html
  * https://api.rubyonrails.org/classes/ActiveModel/Dirty.html
  * https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/ClassMethods.html
  * https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html