### PR TITLE
Add class-level `Rails::Engine.root` and `.load_seed` sigs

### DIFF
--- a/rbi/annotations/railties.rbi
+++ b/rbi/annotations/railties.rbi
@@ -69,9 +69,20 @@ end
 class Rails::Engine < ::Rails::Railtie
   class << self
     # @shim: delegated to the instance using `method_missing`
+    sig { void }
+    def load_seed; end
+
+    # @shim: delegated to the instance using `method_missing`
+    sig { returns(Pathname) }
+    def root; end
+
+    # @shim: delegated to the instance using `method_missing`
     sig { params(block: T.nilable(T.proc.bind(ActionDispatch::Routing::Mapper).void)).returns(ActionDispatch::Routing::RouteSet) }
     def routes(&block); end
   end
+
+  sig { void }
+  def load_seed; end
 
   sig { params(block: T.nilable(T.proc.bind(ActionDispatch::Routing::Mapper).void)).returns(ActionDispatch::Routing::RouteSet) }
   def routes(&block); end


### PR DESCRIPTION
`Rails::Railtie` defines a class-level `method_missing` that forwards unknown class methods to the railtie's singleton `instance`, so calls like `MyEngine.root` and `MyEngine.load_seed` work at runtime but are invisible to Sorbet and Tapioca.

This adds class-level `root` and `load_seed` declarations to `Rails::Engine`, following the existing `# @shim: delegated to the instance using 'method_missing'` precedent already in this file for `Engine.routes`. Since class methods are inherited by singleton classes, one declaration here covers every engine subclass.

`Engine.root` in particular is a common call in apps that load data files from an engine (`MyEngine.root.join('data/...')`), and `Engine.load_seed` is typically called from a host app's `seeds.rb`.

Rails documents this calling pattern in the [`load_seed` API docs](https://api.rubyonrails.org/classes/Rails/Engine.html#method-i-load_seed) (`MyEngine::Engine.load_seed`); the forwarding itself is [`Rails::Railtie.method_missing`](https://github.com/rails/rails/blob/v8.1.3/railties/lib/rails/railtie.rb#L215-L227).

An instance-level `root` sig is deliberately omitted: the Tapioca-generated RBI for railties defines `Rails::Engine#root` with a splatted parameter list (it is defined via `delegate`), so a zero-arity annotation fails the static check with a 4010 redefinition error.
