### PR TITLE
Add HTTP verb annotations to faraday

### DIFF
--- a/rbi/annotations/faraday.rbi
+++ b/rbi/annotations/faraday.rbi
@@ -10,6 +10,83 @@ module Faraday
       ).returns(Faraday::Connection)
     end
     def new(url = nil, options = {}, &block); end
+
+    # @method_missing: proxied to Faraday.default_connection, a Faraday::Connection
+    sig do
+      params(
+        url: T.nilable(T.any(String, URI::Generic)),
+        params: T.nilable(T::Hash[T.untyped, T.untyped]),
+        headers: T.nilable(T::Hash[T.untyped, T.untyped]),
+        block: T.nilable(T.proc.params(request: Faraday::Request).void)
+      ).returns(Faraday::Response)
+    end
+    def get(url = nil, params = nil, headers = nil, &block); end
+
+    # @method_missing: proxied to Faraday.default_connection, a Faraday::Connection
+    sig do
+      params(
+        url: T.nilable(T.any(String, URI::Generic)),
+        params: T.nilable(T::Hash[T.untyped, T.untyped]),
+        headers: T.nilable(T::Hash[T.untyped, T.untyped]),
+        block: T.nilable(T.proc.params(request: Faraday::Request).void)
+      ).returns(Faraday::Response)
+    end
+    def head(url = nil, params = nil, headers = nil, &block); end
+
+    # @method_missing: proxied to Faraday.default_connection, a Faraday::Connection
+    sig do
+      params(
+        url: T.nilable(T.any(String, URI::Generic)),
+        params: T.nilable(T::Hash[T.untyped, T.untyped]),
+        headers: T.nilable(T::Hash[T.untyped, T.untyped]),
+        block: T.nilable(T.proc.params(request: Faraday::Request).void)
+      ).returns(Faraday::Response)
+    end
+    def delete(url = nil, params = nil, headers = nil, &block); end
+
+    # @method_missing: proxied to Faraday.default_connection, a Faraday::Connection
+    sig do
+      params(
+        url: T.nilable(T.any(String, URI::Generic)),
+        params: T.nilable(T::Hash[T.untyped, T.untyped]),
+        headers: T.nilable(T::Hash[T.untyped, T.untyped]),
+        block: T.nilable(T.proc.params(request: Faraday::Request).void)
+      ).returns(Faraday::Response)
+    end
+    def trace(url = nil, params = nil, headers = nil, &block); end
+
+    # @method_missing: proxied to Faraday.default_connection, a Faraday::Connection
+    sig do
+      params(
+        url: T.nilable(T.any(String, URI::Generic)),
+        body: T.untyped,
+        headers: T.nilable(T::Hash[T.untyped, T.untyped]),
+        block: T.nilable(T.proc.params(request: Faraday::Request).void)
+      ).returns(Faraday::Response)
+    end
+    def post(url = nil, body = nil, headers = nil, &block); end
+
+    # @method_missing: proxied to Faraday.default_connection, a Faraday::Connection
+    sig do
+      params(
+        url: T.nilable(T.any(String, URI::Generic)),
+        body: T.untyped,
+        headers: T.nilable(T::Hash[T.untyped, T.untyped]),
+        block: T.nilable(T.proc.params(request: Faraday::Request).void)
+      ).returns(Faraday::Response)
+    end
+    def put(url = nil, body = nil, headers = nil, &block); end
+
+    # @method_missing: proxied to Faraday.default_connection, a Faraday::Connection
+    sig do
+      params(
+        url: T.nilable(T.any(String, URI::Generic)),
+        body: T.untyped,
+        headers: T.nilable(T::Hash[T.untyped, T.untyped]),
+        block: T.nilable(T.proc.params(request: Faraday::Request).void)
+      ).returns(Faraday::Response)
+    end
+    def patch(url = nil, body = nil, headers = nil, &block); end
   end
 end
 


### PR DESCRIPTION
### Type of Change

- [x] Modify RBI for an existing gem

### Changes

* Gem name: faraday
* Gem version: 2.14.3
* Gem source: [`lib/faraday.rb#L144`](https://github.com/lostisland/faraday/blob/v2.14.3/lib/faraday.rb#L144), [`lib/faraday/methods.rb`](https://github.com/lostisland/faraday/blob/v2.14.3/lib/faraday/methods.rb), [`lib/faraday/connection.rb#L197-L206`](https://github.com/lostisland/faraday/blob/v2.14.3/lib/faraday/connection.rb#L197-L206) and [`#L277-L283`](https://github.com/lostisland/faraday/blob/v2.14.3/lib/faraday/connection.rb#L277-L283)
* Gem API doc: https://www.rubydoc.info/gems/faraday/2.14.3/Faraday/Connection
* Tapioca version: 0.19.1
* Sorbet version: 0.6.13164

Adds the top-level HTTP verb methods. They are the documented entry point for simple usage (`Faraday.get "http://faraday.com"`), but they are defined nowhere: `Faraday.method_missing` is private and forwards to `Faraday.default_connection`, so `tapioca gem` emits nothing for them. Each is tagged `@method_missing`.

* `Faraday.get`, `.head`, `.delete`, `.trace` — the `METHODS_WITH_QUERY` set. `Faraday::Connection` defines them as `(url = nil, params = nil, headers = nil)`, passing `params` to `request.params.update` and yielding the `Faraday::Request` to the block.
* `Faraday.post`, `.put`, `.patch` — the `METHODS_WITH_BODY` set. Same shape with `body` in place of `params`, forwarded straight to `run_request`.
* `url` is `T.nilable(T.any(String, URI::Generic))`, matching `Faraday::Request#url`, which branches on `path.respond_to?(:query)`.
* `body` is left `T.untyped`: `run_request` documents it as `String, Hash, Array, nil` and notes middlewares may support more complex types.
* All seven return `Faraday::Response`, per `run_request` returning `builder.build_response`.

`Faraday.options` is deliberately not annotated: it is in neither constant, and `Connection#options` is overloaded to return the connection options when called with no arguments.

`bundle exec repo check --gem --ref origin/main` passes locally on all four checks.