### PR TITLE
Add annotations for i18n

### DIFF
--- a/index.json
+++ b/index.json
@@ -74,6 +74,7 @@
     ]
   },
   "graphql": {},
+  "i18n": {},
   "kredis": {
     "dependencies": [
       "activemodel",

--- a/rbi/annotations/i18n.rbi
+++ b/rbi/annotations/i18n.rbi
@@ -1,0 +1,42 @@
+# typed: true
+
+module I18n::Base
+  sig { returns(T::Array[Symbol]) }
+  def available_locales; end
+
+  sig do
+    params(value: T.nilable(T.any(String, Symbol, T::Array[T.any(String, Symbol)])))
+      .returns(T.nilable(T.any(String, Symbol, T::Array[T.any(String, Symbol)])))
+  end
+  def available_locales=(value); end
+
+  sig { returns(I18n::Config) }
+  def config; end
+
+  sig { returns(Symbol) }
+  def default_locale; end
+
+  sig { params(value: T.nilable(T.any(String, Symbol))).returns(T.nilable(T.any(String, Symbol))) }
+  def default_locale=(value); end
+
+  sig { returns(String) }
+  def default_separator; end
+
+  sig { params(value: String).returns(String) }
+  def default_separator=(value); end
+
+  sig { returns(T::Boolean) }
+  def enforce_available_locales; end
+
+  sig { params(value: T::Boolean).returns(T::Boolean) }
+  def enforce_available_locales=(value); end
+
+  sig { returns(Symbol) }
+  def locale; end
+
+  sig { params(value: T.nilable(T.any(String, Symbol))).returns(T.nilable(T.any(String, Symbol))) }
+  def locale=(value); end
+
+  sig { returns(I18n::Config) }
+  def writable_config; end
+end


### PR DESCRIPTION
### Type of Change

- [x] Add RBI for a new gem

### Changes

* Gem name: i18n
* Gem version: 1.15.2
* Gem source: https://github.com/ruby-i18n/i18n/blob/v1.15.2/lib/i18n.rb#L96-L108 (the `module_eval` delegator block) and https://github.com/ruby-i18n/i18n/blob/v1.15.2/lib/i18n/config.rb
* Gem API doc: https://rubydoc.info/gems/i18n/1.15.2/I18n/Base
* Tapioca version: 0.19.1
* Sorbet version: 0.6.13164

`I18n::Base` defines `locale`, `default_locale`, `available_locales`,
`default_separator` and `enforce_available_locales` (plus their writers) with
`module_eval` over a hardcoded list, each forwarding to `I18n::Config`. Tapioca
emits them without signatures, so `I18n.locale` and friends are `T.untyped`.
Only methods whose types are fixed by the gem's own source are annotated:

* `config` / `writable_config` → `I18n::Config` — both return the memoized `I18n::Config` (or its dup).
* `locale` → `Symbol` — `Config#locale` falls back to `default_locale`, which is `@@default_locale ||= :en`.
* `default_locale` → `Symbol` — same `||= :en` fallback, so it is never nil.
* `locale=` / `default_locale=` → `T.nilable(T.any(String, Symbol))` — the writers do `locale && locale.to_sym`.
* `available_locales` → `T::Array[Symbol]` — the writer stores `Array(locales).map(&:to_sym)`, and `Backend::Simple#available_locales` returns the symbol keys of the translations hash.
* `available_locales=` → accepts one locale, an array of locales, or nil, since it applies `Array()` then `to_sym`.
* `default_separator` → `String` — `@@default_separator ||= '.'`.
* `enforce_available_locales` → `T::Boolean` — class variable initialized to `true`.

Deliberately left out because their types are genuinely open in the gem:

* `backend` / `backend=` — any object implementing the backend protocol; `I18n::Backend::Base` is not enforced.
* `exception_handler` / `exception_handler=` — documented as anything responding to `#call`.
* `load_path` / `load_path=` — the gem states custom implementations only need to "behave like a Ruby Array", so `T::Array` would over-promise.
* `translate` and friends — return type depends on the stored translation.

`bundle exec repo check --gem --ref upstream/main` passes locally (index, rubocop, rubygems, runtime, static).
