### PR TITLE
Add annotation for pagy

### DIFF
--- a/index.json
+++ b/index.json
@@ -108,6 +108,7 @@
       "mocha/api"
     ]
   },
+  "pagy": {},
   "parse-cron": {},
   "phonelib": {},
   "pundit": {},

--- a/rbi/annotations/pagy.rbi
+++ b/rbi/annotations/pagy.rbi
@@ -1,0 +1,13 @@
+# typed: true
+
+# `Pagy::Method` is included in the app controller/view to provide the `#pagy` method.
+module Pagy::Method
+  protected
+
+  # `paginator` selects the paginator module, and the return value depends on it:
+  # most paginators return a `[Pagy, records]` pair, `:calendar` returns a
+  # `[Pagy::Calendar, Pagy, records]` triplet, and the search paginators return a bare
+  # `Pagy` object in passive mode. Hence the untyped return.
+  sig { params(paginator: Symbol, collection: T.untyped, options: T.untyped).returns(T.untyped) }
+  def pagy(paginator = :offset, collection, **options); end
+end


### PR DESCRIPTION
### Type of Change

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other:

### Changes

* Gem name: pagy
* Gem version: 43.6.2
* Gem source: https://github.com/ddnexus/pagy/blob/e85430530be38b76d4329c2fea7d870dee60e94f/gem/lib/pagy/toolbox/paginators/method.rb#L21
* Gem API doc: https://ddnexus.github.io/pagy/docs/api/paginators/
* Tapioca version: 0.19.1
* Sorbet version: 0.6.13164

Annotates a single method, `Pagy::Method#pagy` — the entry point users `include` into
their controllers/views.

It is defined with `define_method` inside an anonymous `Module.new`, so tapioca's runtime
reflection picks up its arity and `protected` visibility but emits no signature.

* `paginator` is `Symbol`: it is used only as a key into the frozen paginator lookup hash
  in `method.rb`, so anything else raises.
* `collection` and `options` are `T.untyped`: they are forwarded verbatim to whichever
  paginator is selected, and each accepts a different kind of collection (AR relation,
  Array, `Pagy::Search::Arguments`, …).
* The return is deliberately `T.untyped` rather than a tuple, because it varies by
  paginator: `[Pagy, records]` for the offset/countless/countish/keyset family,
  `[Pagy::Calendar, Pagy, records]` for `:calendar`, and a bare `Pagy` object for the
  search paginators in passive mode. A tuple type would be wrong for those callers, and
  Sorbet cannot discriminate on the symbol literal to overload them apart. The comment
  above the sig documents the three shapes instead.

`bundle exec repo check --gem --ref origin/main` passes locally (index, rubocop, rubygems,
runtime, static).