### PR TITLE
Add annotations for ransack

### DIFF
--- a/index.json
+++ b/index.json
@@ -129,6 +129,12 @@
       "rainbow/version"
     ]
   },
+  "ransack": {
+    "requires": [
+      "active_record",
+      "ransack"
+    ]
+  },
   "shopify-money": {
     "requires": [
       "money"

--- a/rbi/annotations/ransack.rbi
+++ b/rbi/annotations/ransack.rbi
@@ -6,15 +6,15 @@ class Ransack::Search
 end
 
 module Ransack::Adapters::ActiveRecord::Base
-  sig { params(auth_object: T.untyped).returns(T::Array[String]) }
+  sig { overridable.params(auth_object: T.untyped).returns(T::Array[String]) }
   def ransackable_associations(auth_object = nil); end
 
-  sig { params(auth_object: T.untyped).returns(T::Array[String]) }
+  sig { overridable.params(auth_object: T.untyped).returns(T::Array[String]) }
   def ransackable_attributes(auth_object = nil); end
 
-  sig { params(auth_object: T.untyped).returns(T::Array[Symbol]) }
+  sig { overridable.params(auth_object: T.untyped).returns(T::Array[Symbol]) }
   def ransackable_scopes(auth_object = nil); end
 
-  sig { params(auth_object: T.untyped).returns(T::Array[String]) }
+  sig { overridable.params(auth_object: T.untyped).returns(T::Array[String]) }
   def ransortable_attributes(auth_object = nil); end
 end

--- a/rbi/annotations/ransack.rbi
+++ b/rbi/annotations/ransack.rbi
@@ -1,0 +1,20 @@
+# typed: true
+
+class Ransack::Search
+  sig { params(opts: T::Hash[T.untyped, T.untyped]).returns(ActiveRecord::Relation) }
+  def result(opts = {}); end
+end
+
+module Ransack::Adapters::ActiveRecord::Base
+  sig { params(auth_object: T.untyped).returns(T::Array[String]) }
+  def ransackable_associations(auth_object = nil); end
+
+  sig { params(auth_object: T.untyped).returns(T::Array[String]) }
+  def ransackable_attributes(auth_object = nil); end
+
+  sig { params(auth_object: T.untyped).returns(T::Array[Symbol]) }
+  def ransackable_scopes(auth_object = nil); end
+
+  sig { params(auth_object: T.untyped).returns(T::Array[String]) }
+  def ransortable_attributes(auth_object = nil); end
+end


### PR DESCRIPTION
### Type of Change

- [x] Add RBI for a new gem
- [ ] Modify RBI for an existing gem
- [ ] Other:

### Changes

* Gem name: `ransack`
* Gem version: 4.4.1
* Gem source: [`lib/ransack/adapters/active_record/base.rb`](https://github.com/activerecord-hackery/ransack/blob/v4.4.1/lib/ransack/adapters/active_record/base.rb#L37-L63), [`lib/ransack/search.rb#L44`](https://github.com/activerecord-hackery/ransack/blob/v4.4.1/lib/ransack/search.rb#L44)
* Gem API doc: https://activerecord-hackery.github.io/ransack/going-further/other-notes/#authorization-allowlistingblocklisting
* Tapioca version: 0.19.1
* Sorbet version: 0.6.13164

`ransack` ships no signatures, so tapioca emits these five methods sig-less. They are the methods application code actually touches: every host model must override the four allowlist methods, and `result` is how a search is turned into a query.

* `Ransack::Adapters::ActiveRecord::Base#ransackable_attributes` / `#ransackable_associations` → `T::Array[String]`: the default implementations return `authorizable_ransackable_attributes` / `_associations`, which are `column_names + _ransackers.keys + _ransack_aliases.keys + attribute_aliases.keys` and `reflect_on_all_associations.map { |a| a.name.to_s }` — strings in both cases, and the doc comments say "as an array of strings".
* `#ransortable_attributes` → `T::Array[String]`: delegates to `ransackable_attributes(auth_object)`.
* `#ransackable_scopes` → `T::Array[Symbol]`: returns `[]`, and its doc comment specifies "a whitelist array of *symbols*".
* `Ransack::Search#result` → `ActiveRecord::Relation`: returns `@context.evaluate(self, opts)`; `Context.for` only ever builds `Ransack::Adapters::ActiveRecord::Context` (the AR adapter is the only one the gem ships), and both branches of its `evaluate` (`relation.distinct` or `relation`) return a relation.

`auth_object` is left `T.untyped` — the gem passes whatever the host app puts in `Search`'s `auth_object:` option and never inspects it.

The index entry needs `requires: ["active_record", "ransack"]`: `require "ransack"` alone defers ActiveRecord to an `ActiveSupport.on_load(:active_record)` hook that never fires, so `ActiveRecord::Relation` does not resolve in the static check. No `dependencies` entry — `activerecord` is already a runtime dependency of the gem.

`bundle exec repo check --gem --ref origin/main` passes all five checks locally.