### PR TITLE
Add annotations for the alba gem

### DIFF
--- a/index.json
+++ b/index.json
@@ -46,6 +46,7 @@
       "active_support/test_case"
     ]
   },
+  "alba": {},
   "aws-sdk-acm": {
     "dependencies": [
       "nokogiri"

--- a/rbi/annotations/alba.rbi
+++ b/rbi/annotations/alba.rbi
@@ -1,0 +1,173 @@
+# typed: true
+
+module Alba::Resource::ClassMethods
+  sig do
+    params(
+      name: T.any(String, Symbol),
+      condition: T.nilable(Proc),
+      resource: T.nilable(T.any(Module, String, Proc)),
+      serializer: T.nilable(T.any(Module, String, Proc)),
+      source: T.nilable(Proc),
+      key: T.nilable(T.any(String, Symbol)),
+      with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      params: T::Hash[T.untyped, T.untyped],
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.untyped).void),
+    ).void
+  end
+  def association(name, condition = nil, resource: nil, serializer: nil, source: nil, key: nil, with_traits: nil, params: T.unsafe(nil), **options, &block); end
+
+  sig do
+    params(
+      name: T.nilable(T.any(String, Symbol)),
+      if: T.nilable(T.any(Symbol, Proc)),
+      name_with_type: T.untyped,
+      block: T.proc.bind(T.untyped).params(object: T.untyped).returns(T.untyped),
+    ).void
+  end
+  def attribute(name = nil, if: nil, **name_with_type, &block); end
+
+  sig do
+    params(
+      attrs: T.any(String, Symbol),
+      if: T.nilable(T.any(Symbol, Proc)),
+      attrs_with_types: T.untyped,
+    ).void
+  end
+  def attributes(*attrs, if: nil, **attrs_with_types); end
+
+  sig { params(key: T.any(String, Symbol)).void }
+  def collection_key(key); end
+
+  sig do
+    params(
+      name: T.any(String, Symbol),
+      condition: T.nilable(Proc),
+      resource: T.nilable(T.any(Module, String, Proc)),
+      serializer: T.nilable(T.any(Module, String, Proc)),
+      source: T.nilable(Proc),
+      key: T.nilable(T.any(String, Symbol)),
+      with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      params: T::Hash[T.untyped, T.untyped],
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.untyped).void),
+    ).void
+  end
+  def has_many(name, condition = nil, resource: nil, serializer: nil, source: nil, key: nil, with_traits: nil, params: T.unsafe(nil), **options, &block); end
+
+  sig do
+    params(
+      name: T.any(String, Symbol),
+      condition: T.nilable(Proc),
+      resource: T.nilable(T.any(Module, String, Proc)),
+      serializer: T.nilable(T.any(Module, String, Proc)),
+      source: T.nilable(Proc),
+      key: T.nilable(T.any(String, Symbol)),
+      with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      params: T::Hash[T.untyped, T.untyped],
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.untyped).void),
+    ).void
+  end
+  def has_one(name, condition = nil, resource: nil, serializer: nil, source: nil, key: nil, with_traits: nil, params: T.unsafe(nil), **options, &block); end
+
+  sig { params(mod: Module, block: T.nilable(T.proc.bind(T.untyped).void)).void }
+  def helper(mod = T.unsafe(nil), &block); end
+
+  sig { params(file: T.nilable(String), inline: T.nilable(Proc)).void }
+  def layout(file: nil, inline: nil); end
+
+  sig do
+    params(
+      name: T.any(String, Symbol),
+      condition: T.nilable(Proc),
+      resource: T.nilable(T.any(Module, String, Proc)),
+      serializer: T.nilable(T.any(Module, String, Proc)),
+      source: T.nilable(Proc),
+      key: T.nilable(T.any(String, Symbol)),
+      with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      params: T::Hash[T.untyped, T.untyped],
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.untyped).void),
+    ).void
+  end
+  def many(name, condition = nil, resource: nil, serializer: nil, source: nil, key: nil, with_traits: nil, params: T.unsafe(nil), **options, &block); end
+
+  sig do
+    params(
+      key: T.nilable(T.any(String, Symbol)),
+      block: T.nilable(T.proc.bind(T.untyped).returns(T::Hash[T.untyped, T.untyped])),
+    ).void
+  end
+  def meta(key = :meta, &block); end
+
+  sig do
+    params(
+      name: T.any(String, Symbol),
+      options: T.untyped,
+      block: T.proc.bind(T.untyped).void,
+    ).void
+  end
+  def nested(name, **options, &block); end
+
+  sig do
+    params(
+      name: T.any(String, Symbol),
+      options: T.untyped,
+      block: T.proc.bind(T.untyped).void,
+    ).void
+  end
+  def nested_attribute(name, **options, &block); end
+
+  sig do
+    params(
+      handler: T.nilable(Symbol),
+      block: T.nilable(T.proc.params(error: T.untyped, object: T.untyped, key: T.untyped, attribute: T.untyped, resource_class: T.untyped).returns(T::Array[T.untyped])),
+    ).void
+  end
+  def on_error(handler = nil, &block); end
+
+  sig do
+    params(
+      block: T.nilable(T.proc.bind(T.untyped).params(object: T.untyped, key: T.untyped, attribute: T.untyped).returns(T.untyped)),
+    ).void
+  end
+  def on_nil(&block); end
+
+  sig do
+    params(
+      name: T.any(String, Symbol),
+      condition: T.nilable(Proc),
+      resource: T.nilable(T.any(Module, String, Proc)),
+      serializer: T.nilable(T.any(Module, String, Proc)),
+      source: T.nilable(Proc),
+      key: T.nilable(T.any(String, Symbol)),
+      with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      params: T::Hash[T.untyped, T.untyped],
+      options: T.untyped,
+      block: T.nilable(T.proc.bind(T.untyped).void),
+    ).void
+  end
+  def one(name, condition = nil, resource: nil, serializer: nil, source: nil, key: nil, with_traits: nil, params: T.unsafe(nil), **options, &block); end
+
+  sig { void }
+  def prefer_object_method!; end
+
+  sig { void }
+  def prefer_resource_method!; end
+
+  sig { params(key: T.any(String, Symbol), key_for_collection: T.nilable(T.any(String, Symbol))).void }
+  def root_key(key, key_for_collection = nil); end
+
+  sig { void }
+  def root_key!; end
+
+  sig { params(key: T.any(String, Symbol)).void }
+  def root_key_for_collection(key); end
+
+  sig { params(name: T.any(String, Symbol), block: T.proc.bind(T.untyped).void).void }
+  def trait(name, &block); end
+
+  sig { params(type: T.any(String, Symbol), root: T::Boolean, cascade: T::Boolean).void }
+  def transform_keys(type, root: true, cascade: true); end
+end

--- a/rbi/annotations/alba.rbi
+++ b/rbi/annotations/alba.rbi
@@ -5,8 +5,8 @@ module Alba::Resource::ClassMethods
     params(
       name: T.any(String, Symbol),
       condition: T.nilable(Proc),
-      resource: T.nilable(T.any(Module, String, Proc)),
-      serializer: T.nilable(T.any(Module, String, Proc)),
+      resource: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
+      serializer: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
       source: T.nilable(Proc),
       key: T.nilable(T.any(String, Symbol)),
       with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),
@@ -43,8 +43,8 @@ module Alba::Resource::ClassMethods
     params(
       name: T.any(String, Symbol),
       condition: T.nilable(Proc),
-      resource: T.nilable(T.any(Module, String, Proc)),
-      serializer: T.nilable(T.any(Module, String, Proc)),
+      resource: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
+      serializer: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
       source: T.nilable(Proc),
       key: T.nilable(T.any(String, Symbol)),
       with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),
@@ -59,8 +59,8 @@ module Alba::Resource::ClassMethods
     params(
       name: T.any(String, Symbol),
       condition: T.nilable(Proc),
-      resource: T.nilable(T.any(Module, String, Proc)),
-      serializer: T.nilable(T.any(Module, String, Proc)),
+      resource: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
+      serializer: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
       source: T.nilable(Proc),
       key: T.nilable(T.any(String, Symbol)),
       with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),
@@ -81,8 +81,8 @@ module Alba::Resource::ClassMethods
     params(
       name: T.any(String, Symbol),
       condition: T.nilable(Proc),
-      resource: T.nilable(T.any(Module, String, Proc)),
-      serializer: T.nilable(T.any(Module, String, Proc)),
+      resource: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
+      serializer: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
       source: T.nilable(Proc),
       key: T.nilable(T.any(String, Symbol)),
       with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),
@@ -122,7 +122,7 @@ module Alba::Resource::ClassMethods
   sig do
     params(
       handler: T.nilable(Symbol),
-      block: T.nilable(T.proc.params(error: T.untyped, object: T.untyped, key: T.untyped, attribute: T.untyped, resource_class: T.untyped).returns(T::Array[T.untyped])),
+      block: T.nilable(T.proc.params(error: T.untyped, object: T.untyped, key: T.untyped, attribute: T.untyped, resource_class: T.untyped).returns(T.untyped)),
     ).void
   end
   def on_error(handler = nil, &block); end
@@ -138,8 +138,8 @@ module Alba::Resource::ClassMethods
     params(
       name: T.any(String, Symbol),
       condition: T.nilable(Proc),
-      resource: T.nilable(T.any(Module, String, Proc)),
-      serializer: T.nilable(T.any(Module, String, Proc)),
+      resource: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
+      serializer: T.nilable(T.any(T::Class[Alba::Resource], String, Proc)),
       source: T.nilable(Proc),
       key: T.nilable(T.any(String, Symbol)),
       with_traits: T.nilable(T.any(Symbol, T::Array[Symbol])),


### PR DESCRIPTION
### Type of Change

- [x] Add RBI for a new gem

### Changes

* Gem name: alba
* Gem version: 4.0.0
* Gem source: https://github.com/okuramasafumi/alba/blob/main/lib/alba/resource.rb
* Gem API doc: https://rubydoc.info/gems/alba/Alba/Resource/ClassMethods
* Tapioca version: 0.19.1
* Sorbet version: 0.6.13164

Alba ships no signatures, so tapioca emits every `Alba::Resource::ClassMethods` DSL macro sig-less. This adds signatures for the class-level macros used to define a resource. Every parameter list matches the one tapioca generates; every type is taken from the method body and its YARD doc.

* `attribute` / `attributes` — `name` is `String`/`Symbol`, `if:` is `Symbol` or `Proc` (`Alba::ConditionalAttribute#condition_passes?` branches on exactly those two), extra keywords are the untyped `name => type` pairs handed to `Alba::TypedAttribute`.
* `association` and its aliases `one`, `many`, `has_one`, `has_many` — types taken from the YARD `@param` tags on `association`, which the aliases share; `resource:`/`serializer:` accept a resource class, a `String`, or a `Proc`.
* `nested_attribute` / `nested`, `trait` — block is `class_eval`'d, so it is bound to an untyped self and returns nothing useful.
* `on_error` — `handler` is one of `:raise`, `:ignore`, `:nullify`; the block is called as `on_error.call(error, obj, key, attribute, klass)` and its `[key, value]` return is destructured, hence `T::Array[T.untyped]`.
* `on_nil` — called as `instance_exec(obj, key, attribute, &nil_handler)`.
* `meta`, `layout`, `helper`, `collection_key`, `root_key`, `root_key!`, `root_key_for_collection`, `transform_keys`, `prefer_object_method!`, `prefer_resource_method!` — direct reads of the assignments in each body.

Two notes:

* The block on `attribute` (and on `trait` and `nested_attribute`) is declared non-nilable. It is syntactically optional, but all three raise `ArgumentError` immediately when it is absent, so a call without a block can only ever fail at runtime.
* `transform_keys!` is left unannotated: it returns the anonymous `dup` of the resource class, is marked experimental in the source, and I could not type it honestly.

Instance methods (`serialize`, `as_json`, `serializable_hash`) are deliberately left out of this first pass — `serializable_hash` returns a `Hash` or an `Array` depending on whether the object is a collection, and a union return there would tighten code that type-checks today.

`bundle exec repo check --gem --ref upstream/main` passes locally on all five checks (index, rubocop, rubygems, runtime, static).